### PR TITLE
SAP006-A integração Protheus x SAP do Custo

### DIFF
--- a/Integracoes/SAP/Montadora/CMVSAP08.prw
+++ b/Integracoes/SAP/Montadora/CMVSAP08.prw
@@ -117,6 +117,7 @@ user function CMVSAP08( aParam )
 	cQry += " 							AND SZ7B.Z7_SERORI  = SZ7.Z7_SERORI  " + CRLF
 	cQry += " 							AND SZ7B.Z7_CLIFOR  = SZ7.Z7_CLIFOR   " + CRLF
 	cQry += " 							AND SZ7B.Z7_LOJA    = SZ7.Z7_LOJA " + CRLF
+	cQry += "							AND SZ7B.Z7_XCHAVE  = SZ7.Z7_XCHAVE " + CRLF
 	cQry += " 							AND SZ7B.D_E_L_E_T_ = ' ' " + CRLF
 	cQry += " 							AND SZ7B.Z7_XSTATUS = 'E' " + CRLF
 	cQry += " 							AND ROWNUM = 1 ) " + CRLF
@@ -634,7 +635,12 @@ user function CMVSAP08( aParam )
 					Endif	
 				EndIf
 			EndIf
-
+		else
+			If lIsBlind
+				Conout("Erro de Conexão CMVSAP08 Error Http: " + Str(nStatuHttp) )
+			else
+				Alert("Erro de Conexão Error Http: " + Str(nStatuHttp) )
+			endif
 		EndIf
 		(cAliasQry)->(dbSkip())
 	EndDo


### PR DESCRIPTION
-Melhoria para processar os registros do custo (Z7_ORIGEM = 'CMVCTBCUS' e 'CTBA102') com status Pendente (Z7_XSTATUS='P').
-Adicionado mensagem em caso de falha na conexão entre Protheus x SAP.
-Adicionar o relacionamento SZ7B.Z7_XCHAVE  = SZ7.Z7_XCHAVE na query para trazer os registros corretos

**Termo de aceite:** [GAP-SAP006 - Integração do Custo Protheus x SAP.pdf](https://github.com/Caoa-Montadora-de-Veiculos-Ltda/Protheus/files/11511648/GAP-SAP006.-.Integracao.do.Custo.Protheus.x.SAP.pdf)
