### PR TITLE
CHG0032426 - SAP007 - Erro de Schema do XML de envio ao SAP

### DIFF
--- a/Integracoes/SAP/Montadora/CMVSAP08.prw
+++ b/Integracoes/SAP/Montadora/CMVSAP08.prw
@@ -446,7 +446,7 @@ user function CMVSAP08( aParam )
 		
 					cUsu := Alltrim(Subs((cAliasCT2)->CT2_ORIGEM,9,15)) 
 					nPos := aScan( aSimple, {|aVet| aVet[2] == "textoCabecalhoDocumento" } )
-					xRet := oWsdl:SetValue( aSimple[nPos][1], IIf(!Empty((cAliasCT2)->CT2_XNOME),Alltrim((cAliasCT2)->CT2_XNOME),IIf(!Empty(cUsu),cUsu,Embaralha((cAliasCT2)->CT2_USERGI)))) 	//textoCabecalhoDocumento - Nome do usuário que efetuou o lançamento
+					xRet := oWsdl:SetValue( aSimple[nPos][1], IIf(!Empty((cAliasCT2)->CT2_XNOME),Alltrim((cAliasCT2)->CT2_XNOME),IIf(!Empty(cUsu),cUsu,Embaralha((cAliasCT2)->CT2_USERGI)))) //textoCabecalhoDocumento - Nome do usuário que efetuou o lançamento
 					If !xRet
 						U_ZF12GENSAP((cAliasQry)->Z7_FILIAL,(cAliasQry)->Z7_XTABELA,(cAliasQry)->Z7_XCHAVE,(cAliasQry)->Z7_XSEQUEN,"E","textoCabecalhoDocumento Erro: " + oWsdl:cError)
 						(cAliasQry)->(dbSkip())

--- a/Integracoes/SAP/Montadora/CMVSAP08.prw
+++ b/Integracoes/SAP/Montadora/CMVSAP08.prw
@@ -446,7 +446,7 @@ user function CMVSAP08( aParam )
 		
 					cUsu := Alltrim(Subs((cAliasCT2)->CT2_ORIGEM,9,15)) 
 					nPos := aScan( aSimple, {|aVet| aVet[2] == "textoCabecalhoDocumento" } )
-					xRet := oWsdl:SetValue( aSimple[nPos][1], IIf(!Empty((cAliasCT2)->CT2_XNOME),Alltrim((cAliasCT2)->CT2_XNOME),IIf(!Empty(cUsu),cUsu,Embaralha((cAliasCT2)->CT2_USERGI)))) //textoCabecalhoDocumento - Nome do usuário que efetuou o lançamento
+					xRet := oWsdl:SetValue( aSimple[nPos][1] , Substr( IIf(!Empty((cAliasCT2)->CT2_XNOME),Alltrim((cAliasCT2)->CT2_XNOME),IIf(!Empty(cUsu),cUsu,Embaralha((cAliasCT2)->CT2_USERGI))),1,25))
 					If !xRet
 						U_ZF12GENSAP((cAliasQry)->Z7_FILIAL,(cAliasQry)->Z7_XTABELA,(cAliasQry)->Z7_XCHAVE,(cAliasQry)->Z7_XSEQUEN,"E","textoCabecalhoDocumento Erro: " + oWsdl:cError)
 						(cAliasQry)->(dbSkip())

--- a/Ponto de Entrada/MT094LOK_PE.PRW
+++ b/Ponto de Entrada/MT094LOK_PE.PRW
@@ -48,16 +48,16 @@ Local aArea	      := GetArea()
          LIMPEZA->(dbGoTop())
          IF LIMPEZA->(!EOF())
             While LIMPEZA->(!EOF())
-               If SCR->(dbSeek(xFilial("SCR")+"CP"+LIMPEZA->CR_NUM))
-                  While SCR->(!EOF()) .AND. SCR->CR_FILIAL = LIMPEZA->CR_FILIAL .AND. SCR->CR_NUM = LIMPEZA->CR_NUM
-                     RecLock( ("SCR"), .F. )
+               While SCR->(!EOF()) .AND. SCR->CR_FILIAL = LIMPEZA->CR_FILIAL .AND. SCR->CR_NUM = LIMPEZA->CR_NUM
+                     If SCR->(dbSeek(xFilial("SCR")+"CP"+LIMPEZA->CR_NUM))
+                        RecLock( ("SCR"), .F. )
                         SCR->CR_XVLLIB := 0
                         MsUnlock()
+                     Endif
                      SCR->(dbSkip())
-                  EndDo
-               Endif
+               End
                LIMPEZA->(dbSkip())
-            ENDDO   
+            END   
          ENDIF
          LIMPEZA->(DbCloseArea())
 
@@ -85,18 +85,18 @@ Local aArea	      := GetArea()
                cQry1 := ChangeQuery(cQry1)
                DbUseArea(.T.,"TOPCONN",TCGENQRY(,,cQry1),"cVLIBER",.T.,.T.)
                
-               If SCR->(dbSeek(xFilial("SCR")+"CP"+CONTRATO->C3_NUM))
-                  While SCR->(!EOF()) .AND. SCR->CR_FILIAL = CONTRATO->C3_FILIAL .AND. SCR->CR_NUM = CONTRATO->C3_NUM
+               While SCR->(!EOF()) .AND. SCR->CR_FILIAL = CONTRATO->C3_FILIAL .AND. SCR->CR_NUM = CONTRATO->C3_NUM
+                  If SCR->(dbSeek(xFilial("SCR")+"CP"+CONTRATO->C3_NUM))
                      RecLock( ("SCR"), .F. )
-                        SCR->CR_XVLLIB := cVLIBER->nTOTAL
+                     SCR->CR_XVLLIB := cVLIBER->nTOTAL
                      MsUnlock()
-                     SCR->(dbSkip())
-                  EndDo
-               Endif
+                  Endif
+                  SCR->(dbSkip())
+               End
 
                cVLIBER->(DbCloseArea())
                
-               //Ler o próximo contrato
+               //Ler o prÃ³ximo contrato
                CONTRATO->(dbSkip())
             END   
             SCR->(dbSeek(cChave))

--- a/Ponto de Entrada/MT094LOK_PE.PRW
+++ b/Ponto de Entrada/MT094LOK_PE.PRW
@@ -48,16 +48,16 @@ Local aArea	      := GetArea()
          LIMPEZA->(dbGoTop())
          IF LIMPEZA->(!EOF())
             While LIMPEZA->(!EOF())
-               While SCR->(!EOF()) .AND. SCR->CR_FILIAL = LIMPEZA->CR_FILIAL .AND. SCR->CR_NUM = LIMPEZA->CR_NUM
-                     If SCR->(dbSeek(xFilial("SCR")+"CP"+LIMPEZA->CR_NUM))
-                        RecLock( ("SCR"), .F. )
+               If SCR->(dbSeek(xFilial("SCR")+"CP"+LIMPEZA->CR_NUM))
+                  While SCR->(!EOF()) .AND. SCR->CR_FILIAL = LIMPEZA->CR_FILIAL .AND. SCR->CR_NUM = LIMPEZA->CR_NUM
+                     RecLock( ("SCR"), .F. )
                         SCR->CR_XVLLIB := 0
                         MsUnlock()
-                     Endif
                      SCR->(dbSkip())
-               End
+                  EndDo
+               Endif
                LIMPEZA->(dbSkip())
-            END   
+            ENDDO   
          ENDIF
          LIMPEZA->(DbCloseArea())
 
@@ -85,14 +85,14 @@ Local aArea	      := GetArea()
                cQry1 := ChangeQuery(cQry1)
                DbUseArea(.T.,"TOPCONN",TCGENQRY(,,cQry1),"cVLIBER",.T.,.T.)
                
-               While SCR->(!EOF()) .AND. SCR->CR_FILIAL = CONTRATO->C3_FILIAL .AND. SCR->CR_NUM = CONTRATO->C3_NUM
-                  If SCR->(dbSeek(xFilial("SCR")+"CP"+CONTRATO->C3_NUM))
+               If SCR->(dbSeek(xFilial("SCR")+"CP"+CONTRATO->C3_NUM))
+                  While SCR->(!EOF()) .AND. SCR->CR_FILIAL = CONTRATO->C3_FILIAL .AND. SCR->CR_NUM = CONTRATO->C3_NUM
                      RecLock( ("SCR"), .F. )
-                     SCR->CR_XVLLIB := cVLIBER->nTOTAL
+                        SCR->CR_XVLLIB := cVLIBER->nTOTAL
                      MsUnlock()
-                  Endif
-                  SCR->(dbSkip())
-               End
+                     SCR->(dbSkip())
+                  EndDo
+               Endif
 
                cVLIBER->(DbCloseArea())
                

--- a/Ponto de Entrada/MT094LOK_PE.PRW
+++ b/Ponto de Entrada/MT094LOK_PE.PRW
@@ -96,7 +96,7 @@ Local aArea	      := GetArea()
 
                cVLIBER->(DbCloseArea())
                
-               //Ler o prÃ³ximo contrato
+               //Ler o próximo contrato
                CONTRATO->(dbSkip())
             END   
             SCR->(dbSeek(cChave))


### PR DESCRIPTION
Ao gerar o XML de integração com o SAP a TAG <textoCabecalhoDocumento> tem o tamanho máximo de 25 caracteres, o nome do Vendedor.
Foi limitado no fonte CMVSAP008.prw para 25 caracteres assim prevenindo erros futuros
