### PR TITLE
CHG0032442 - EIC133 - Removido os Campos W3_FLUXO e W3_SEQ da consulta na Gravação da Capa da PO

### DIFF
--- a/SIGAEIC/Funcao/GRVPO400.prw
+++ b/SIGAEIC/Funcao/GRVPO400.prw
@@ -203,8 +203,8 @@ User Function xGRVP400()
 		_cQrySW3 += "							AND ?				 = SW5.D_E_L_E_T_			"
 		_cQrySW3 += " WHERE	SW3.W3_FILIAL		= ?												"
 		_cQrySW3 += " 	AND	SW3.W3_PO_NUM		= ?												"
-		_cQrySW3 += " 	AND	SW3.W3_FLUXO 		= ?												"
-		_cQrySW3 += " 	AND SW3.W3_SEQ	 		= ?												"
+		//_cQrySW3 += " 	AND	SW3.W3_FLUXO 		= ?												"
+		//_cQrySW3 += " 	AND SW3.W3_SEQ	 		= ?												"
 		_cQrySW3 += "	AND SW3.D_E_L_E_T_		= ?												"
 	EndIf
 
@@ -217,8 +217,8 @@ User Function xGRVP400()
 	Aadd(aBind,Space(01)		)
 	Aadd(aBind,xFilial("SW3")	)
 	Aadd(aBind,SW2->W2_PO_NUM	)
-	Aadd(aBind,'7'				)
-	Aadd(aBind,'1'				)
+	//Aadd(aBind,'7'				)
+	//Aadd(aBind,'1'				)
 	Aadd(aBind,Space(01)		)
 
 	DbUseArea(.T., "TOPCONN", TCGenQry2(,, _cQrySW3, aBind), 'QSW3', .F., .T.)


### PR DESCRIPTION
Removido os Campos W3_FLUXO e W3_SEQ da consulta que pega as informações dos itens, para gravar na Capa da P.O.(SW2) e
 as Informações no Pedido de Compa(SC7) corretamente.


*Termo de Entrega: * 
[GAP -EIC133-As PO's do tipo CBU não estão gravando o tipo de importação.pdf](https://github.com/Caoa-Montadora-de-Veiculos-Ltda/Protheus/files/11636609/GAP.-EIC133-As.PO.s.do.tipo.CBU.nao.estao.gravando.o.tipo.de.importacao.pdf)

