### PR TITLE
CHG0032462 - FAT120 - Alteração da descrição na Impressão da Danfe

### DIFF
--- a/SIGAFAT/Função/nfesefaz.prw
+++ b/SIGAFAT/Função/nfesefaz.prw
@@ -2667,8 +2667,10 @@ If cTipo == "1"
 						//Caso haja a amarraca, o codigo e descricao do produto, assumem o conteudo da SA7 ou SA5
 		
 						cCodProd  := (cAliasSD2)->D2_COD	            
-						cDescProd := IIF(Empty(SC6->C6_DESCRI),SB1->B1_DESC,SC6->C6_DESCRI) 
-						 
+    //*******************************************************************
+						//cDescProd := IIF(Empty(SC6->C6_DESCRI),SB1->B1_DESC,SC6->C6_DESCRI)
+						cDescProd := SB1->B1_DESC
+	//******************************************************************
 						If !Empty((cAliasSD2)->D2_IDENTB6) .And. lNFPTER  
 				         	If SC5->C5_TIPO == "N" 
 						         //--A7_FILIAL + A7_CLIENTE + A7_LOJA + A7_PRODUTO


### PR DESCRIPTION
Alterado para pegar a descrição do produto do cadastro de produto(SB1).
pois ao pegar a descrição da tabela SC6 - Item do Pedido de venda o qual esta com tamanho menor assim pegando a descrição incompleta.

Obs.: Futuramente será necessário analisar o impacto para aumentar o tamanho do campo de descrição da SC6 igualando a SB1.