### PR TITLE
CHG0032463 - VEI112 - Alteração para pegar o número do pedido da Tabela VRJ

### DIFF
--- a/SIGAVEI/Relatorio/ZVEIR002.PRW
+++ b/SIGAVEI/Relatorio/ZVEIR002.PRW
@@ -12,6 +12,7 @@ Consulta de Faturamento por Tipo
 @since 05/12/2022
 @version 1.0
 @type function
+
 /*/
 
 User Function ZVEIR002()

--- a/SIGAVEI/Relatorio/ZVEIR002.PRW
+++ b/SIGAVEI/Relatorio/ZVEIR002.PRW
@@ -233,8 +233,8 @@ Static Function ZVEIR2QR_Query()
 
 	cQuery +=  CLRF + ;
 	"     SELECT  " + CLRF + ;
-	"          COALESCE( VRK.VRK_PEDIDO , ' ' ) AS VRJ_PEDIDO " + CLRF + ;
-	"         , SC6.C6_PEDCLI AS VRJ_PEDCOM " + CLRF + ;
+	"           COALESCE( VRK.VRK_PEDIDO , ' ' ) AS VRJ_PEDIDO " + CLRF + ;
+	"         , COALESCE( VRJ.VRJ_PEDCOM ,SC6.C6_PEDCLI ) AS VRJ_PEDCOM " + CLRF + ;
 	"         , SD2.D2_PEDIDO " + CLRF + ;
 	"         , COALESCE(VV0.VV0_NUMTRA,' ') as VV0_NUMTRA" + CLRF + ;
 	"         , SC6.C6_ENTREG " + CLRF + ;


### PR DESCRIPTION
Na Consulta de Faturamento (ZVEIR002) na geração da consulta estava pegando o número do pedido de compra da Tabela SC6 o qual somente é preenchido pelo portal comercial.
Foi alterado para pegar o número da Tabela VRJ também, assim priorizando a Tabela VRJ e depois a SC6 assim pegando da tabela que estiver preenchido.