### PR TITLE
CHG0032564 - PCP105 - Rotina backflush de veículos travando.

### DIFF
--- a/SIGAPCP/Funcao/ZPCPF007.PRW
+++ b/SIGAPCP/Funcao/ZPCPF007.PRW
@@ -235,7 +235,7 @@ Local _aSM0			:= {}
 Local _aError		:= {}
 Local _lRet 		:= .F. 
 Local _cChassi		:= ""
-Local _cChaInt 		:= ""
+Local _cChaInt 		:= "000001"
 Local _cTexto		:= ""
 Local _nRegVV1		:= 0
 Local _cPropAtu		:= SuperGetMV( "CMV_VEI011"  ,,"000373")  //000373 Proprietario Atual  NAO CADASTRADO 
@@ -263,7 +263,14 @@ _cChassi	:= Upper(SD3->D3_XCHASSI)
 Private M->VV1_CHASSI :=  _cChassi  //Upper(SH6->H6_XCHASSI) //Necessario fazer isto pois existe validação no TO do Padrão e o mesmo não tem as variaveis de memoria carregadas causando errolog DAC-09/07/2020
 
 _aSM0 		:= FWArrFilAtu(cEmpAnt,cFilAnt)
+
 _cChaInt 	:= GETSXENUM("VV1","VV1_CHAINT")
+WHILE ExistCpo("VV1", _cChaInt , 1)           //Valido se a numeração já existe para evitar erro de Chave duplicada
+	ConfirmSX8()
+	_cChaInt 	:= GETSXENUM("VV1","VV1_CHAINT")
+ENDDO
+ConfirmSX8() // Confirmo o uso da Nuemração para evitar erro na geração de novo numero
+
 //Caso ja esteja cadastrado o Veiculo
 VV1->(DbSetOrder(2))	//VV1_FILIAL+VV1_CHASSI
 If VV1->(DbSeek(xFilial('VV1')+_cChassi))


### PR DESCRIPTION
A rotina ZPCPF010 chama a rotina do Job ZPCPJ002 o qual chama as Rotinas do fonte ZPCPF007.prw o qual está ocorrendo o erro.
VV1010: DB error (Update): -29 File: VV1010 - Error : 1 - ORA-00001: unique constraint (ABDHDU_PROT.VV1010_UNQ) violated
Esse erro é provocado quando é utilizado uma numeração do campo VV1_CHAINT que já foi utilizado na tabela VV1 provocando erro de Chave Unica e assim derrubando o Job ZPCPJ002 provocando o reinicio do processo, desta forma extrapolando o tempo de processamento do JOB.
Foi incluído um tratamento para que a numeração disponibilizada pelo hardlock seja verificado se já foi utilizado e confirmar a numeração antes de usá-la assim evitando que o sistema disponibilize um número já utilizado e não confirmado para inclusão do Veículo, assim forçando a confirmação dos números já utilizados da lista de números disponíveis.

**Termo de Entrega**
[PCP105 - Rotina backflush de veículos travando e necessita reiniciar todos os dias.pdf](https://github.com/Caoa-Montadora-de-Veiculos-Ltda/Protheus/files/11961110/PCP105.-.Rotina.backflush.de.veiculos.travando.e.necessita.reiniciar.todos.os.dias.pdf)

