### PR TITLE
CHG0032610 | EST001 | Bloqueio movimentações e transferência em armazéns específicos (#GAP012)

### DIFF
--- a/Ponto de Entrada/A261TOK_PE.prw
+++ b/Ponto de Entrada/A261TOK_PE.prw
@@ -19,7 +19,11 @@ User Function A261TOK()
     If _cEmp == "2010" //Executa o p.e. Anapolis.
         _lRet := .T.
     Else
-   		_lRet := U_ZESTF010()
+         If lAutoma261 == .F. //executa somente quando não é execauto.
+   		    _lRet := U_ZESTF010()
+        Else
+            _lRet     := .T.
+        EndIf
    EndIf
      	
     RestArea(_aArea)

--- a/Ponto de Entrada/A261TOK_PE.prw
+++ b/Ponto de Entrada/A261TOK_PE.prw
@@ -1,0 +1,26 @@
+#Include "Protheus.ch"
+
+/*/{Protheus.doc} A261TOK_PE
+@author 	Evandro Mariano
+@version  	P12.1.23
+@since  	14/07/2023
+@return  	NIL
+@obs        Ponto de entrada do MATA261
+@project
+@history    
+*/ 
+ 
+User Function A261TOK()
+
+    Local _lRet     := .F.
+    Local _aArea    := GetArea()
+     
+    If _cEmp == "2010" //Executa o p.e. Anapolis.
+        _lRet := .T.
+    Else
+   		_lRet := U_ZESTF010()
+   EndIf
+     	
+    RestArea(_aArea)
+
+Return(_lRet)

--- a/Ponto de Entrada/A261TOK_PE.prw
+++ b/Ponto de Entrada/A261TOK_PE.prw
@@ -14,6 +14,7 @@ User Function A261TOK()
 
     Local _lRet     := .F.
     Local _aArea    := GetArea()
+    Local _cEmp     := FWCodEmp()
      
     If _cEmp == "2010" //Executa o p.e. Anapolis.
         _lRet := .T.

--- a/Ponto de Entrada/MA261EST_PE.prw
+++ b/Ponto de Entrada/MA261EST_PE.prw
@@ -20,7 +20,7 @@ User Function MA261EST()
     If _cEmp == "2010" //Executa o p.e. Anapolis.
         _lRet := .T.
     Else
-        lUserAut := U_ZGENUSER( RetCodUsr() ,"MA261EST_PE",.F.)
+        lUserAut := U_ZGENUSER( RetCodUsr() ,"MA261EST",.F.)
         If lUserAut 
     		_lRet := .T.
         Else

--- a/Ponto de Entrada/MA261EST_PE.prw
+++ b/Ponto de Entrada/MA261EST_PE.prw
@@ -1,16 +1,16 @@
 #Include "Protheus.ch"
 
-/*/{Protheus.doc} OA180VLD_PE
+/*/{Protheus.doc} MA261EST_PE
 @author 	Evandro Mariano
 @version  	P12.1.23
 @since  	14/07/2023
 @return  	NIL
-@obs        Ponto de entrada do OFIOA180
+@obs        Ponto de entrada do MATA241 localizado apos a confirmação do estorno.
 @project
 @history    
 */ 
  
-User Function OA180VLD()
+User Function MA261EST()
 
     Local _lRet     := .F.
     Local _aArea    := GetArea()
@@ -20,12 +20,12 @@ User Function OA180VLD()
     If _cEmp == "2010" //Executa o p.e. Anapolis.
         _lRet := .T.
     Else
-        lUserAut := U_ZGENUSER( RetCodUsr() ,"OA180VLD_PE",.F.)
+        lUserAut := U_ZGENUSER( RetCodUsr() ,"MA261EST_PE",.F.)
         If lUserAut 
     		_lRet := .T.
-        else
+        Else
             _lRet := .F.
-            ApMsgAlert( "Usuário não autorizado para Incluir/Alterar a Equipe Tecnica.","Aviso... [ OA180VLD ]" )
+            ApMsgAlert( "Usuário não autorizado a estornar transferencia multipla.","Aviso... [ MT261EST ] " )
         EndIf
    EndIf
      	

--- a/Ponto de Entrada/MT240EST_PE.prw
+++ b/Ponto de Entrada/MT240EST_PE.prw
@@ -1,16 +1,16 @@
 #Include "Protheus.ch"
 
-/*/{Protheus.doc} MT120OK_PE
+/*/{Protheus.doc} MT240EST_PE
 @author 	Evandro Mariano
 @version  	P12.1.23
 @since  	14/07/2023
 @return  	NIL
-@obs        Ponto de entrada do MATA241 localizado apos a confirmação da inclusao
+@obs        Ponto de entrada do MATA241 localizado apos a confirmação do estorno.
 @project
 @history    
 */ 
  
-User Function MT241TOK()
+User Function MT240EST()
 
     Local _lRet     := .F.
     Local _aArea    := GetArea()
@@ -20,12 +20,12 @@ User Function MT241TOK()
     If _cEmp == "2010" //Executa o p.e. Anapolis.
         _lRet := .T.
     Else
-        lUserAut := U_ZGENUSER( RetCodUsr() ,"MT241TOK_PE",.F.)
+        lUserAut := U_ZGENUSER( RetCodUsr() ,"MT240EST_PE",.F.)
         If lUserAut 
     		_lRet := .T.
         else
             _lRet := .F.
-            ApMsgAlert( "Usuário não autorizado para realizar movimentação multipla.","Aviso... [ MT241TOK ]" )
+            ApMsgAlert( "Usuário não autorizado a estornar movimentação multipla.","Aviso... [ MT240EST ] " )
         EndIf
    EndIf
      	

--- a/Ponto de Entrada/MT240EST_PE.prw
+++ b/Ponto de Entrada/MT240EST_PE.prw
@@ -20,7 +20,7 @@ User Function MT240EST()
     If _cEmp == "2010" //Executa o p.e. Anapolis.
         _lRet := .T.
     Else
-        lUserAut := U_ZGENUSER( RetCodUsr() ,"MT240EST_PE",.F.)
+        lUserAut := U_ZGENUSER( RetCodUsr() ,"MT240EST",.F.)
         If lUserAut 
     		_lRet := .T.
         else

--- a/Ponto de Entrada/MT241TOK_PE.prw
+++ b/Ponto de Entrada/MT241TOK_PE.prw
@@ -1,0 +1,33 @@
+#Include "Protheus.ch"
+
+/*/{Protheus.doc} MT120OK_PE
+@author 	Evandro Mariano
+@version  	P12.1.23
+@since  	14/07/2023
+@return  	NIL
+@obs        Ponto de entrada do MATA241
+@project
+@history    
+*/ 
+ 
+User Function MT241TOK()
+
+    Local _lRet     := .F.
+    Local _aArea    := GetArea()
+    Local lUserAut  := .F.
+     
+    If _cEmp == "2010" //Executa o p.e. Anapolis.
+        _lRet := .T.
+    Else
+        lUserAut := U_ZGENUSER( RetCodUsr() ,"MT241TOK_PE",.T.)
+        If lUserAut 
+    		_lRet := .T.
+        else
+            _lRet := .F.
+            ApMsgAlert( "Usuário não autorizado para realizar movimentação multipla.","[ MT241TOK ] Aviso " )
+        EndIf
+   EndIf
+     	
+    RestArea(_aArea)
+
+Return(_lRet)

--- a/Ponto de Entrada/MT241TOK_PE.prw
+++ b/Ponto de Entrada/MT241TOK_PE.prw
@@ -20,7 +20,7 @@ User Function MT241TOK()
     If _cEmp == "2010" //Executa o p.e. Anapolis.
         _lRet := .T.
     Else
-        lUserAut := U_ZGENUSER( RetCodUsr() ,"MT241TOK_PE",.F.)
+        lUserAut := U_ZGENUSER( RetCodUsr() ,"MT241TOK",.F.)
         If lUserAut 
     		_lRet := .T.
         else

--- a/Ponto de Entrada/OA180VLD_PE.prw
+++ b/Ponto de Entrada/OA180VLD_PE.prw
@@ -1,0 +1,34 @@
+#Include "Protheus.ch"
+
+/*/{Protheus.doc} OA180VLD_PE
+@author 	Evandro Mariano
+@version  	P12.1.23
+@since  	14/07/2023
+@return  	NIL
+@obs        Ponto de entrada do OFIOA180
+@project
+@history    
+*/ 
+ 
+User Function OA180VLD()
+
+    Local _lRet     := .F.
+    Local _aArea    := GetArea()
+    Local lUserAut  := .F.
+    Local _cEmp     := FWCodEmp()
+     
+    If _cEmp == "2010" //Executa o p.e. Anapolis.
+        _lRet := .T.
+    Else
+        lUserAut := U_ZGENUSER( RetCodUsr() ,"OFIOA180",.F.)
+        If lUserAut 
+    		_lRet := .T.
+        else
+            _lRet := .F.
+            ApMsgAlert( "Usuário não autorizado para Incluir/Alterar a Equipe Tecnica.","Aviso... [ OA180VLD ]" )
+        EndIf
+   EndIf
+     	
+    RestArea(_aArea)
+
+Return(_lRet)

--- a/Ponto de Entrada/OA180VLD_PE.prw
+++ b/Ponto de Entrada/OA180VLD_PE.prw
@@ -20,7 +20,7 @@ User Function OA180VLD()
     If _cEmp == "2010" //Executa o p.e. Anapolis.
         _lRet := .T.
     Else
-        lUserAut := U_ZGENUSER( RetCodUsr() ,"OA180VLD_PE",.F.)
+        lUserAut := U_ZGENUSER( RetCodUsr() ,"OA180VLD",.F.)
         If lUserAut 
     		_lRet := .T.
         else

--- a/SIGAEST/Função/ZESTF010.prw
+++ b/SIGAEST/Função/ZESTF010.prw
@@ -12,36 +12,47 @@
 
 User Function ZESTF010()
 
-Local lUserAut  := .F.
-Local _nX       := 0
-Local _lRet     := .F.
-Local _cEmp     := FWCodEmp()
-Private _nLocal
+Local _nX       	:= 0
+Local _lRet     	:= .T.
+Local _cMsgnErro	:= ""
+Local _cIdUser		:= RetCodUsr()
+Local _aAreaVAI    	:= VAI->(GetArea())
+Local _nPrdOrig		:= aScan( aHeader, {|x| AllTrim(x[02]) 			== "D3_COD"				} ) 
+Local _nLocOrig		:= aScan( aHeader, {|x| AllTrim(Upper(x[01])) 	== 'ARMAZEM ORIG.' 		} ) 
+Local _nLocDest 	:= aScan( aHeader, {|x| AllTrim(Upper(x[01])) 	== 'ARMAZEM DESTINO' 	} ) 
 
-	If _cEmp == "2010" //Executa o p.e. Anapolis.
-    	_lRet := .T.
-	Else
-		lUserAut := U_ZGENUSER( RetCodUsr() ,"ZESTF010",.T.)
+	VAI->(DbSetOrder(4)) 
+	If VAI->(DbSeek(xFilial("VAI")+_cIdUser ))
 
-		_cLocal   := aScan(aHeader,{|x|UPPER(Alltrim(x[2])) == "D3_LOCAL"}) 
+		If VAI->VAI_XBLQES == "1"
+			_lRet := .T.
+		ElseIf VAI->VAI_XBLQES == "2"
 
-		For _nX := 1 to Len(aCols)
-		
-			If !aCols[_nX][len(aHeader)+1]
-			
-				If aCols[_nX][_nLocal]$"32/33" 
-			
-				Alert("Saldo insuficiente no armazém "+Acols[_nX][_nLocal]+"!")
-				_lRet     := .F.
-
-				Else
-
-					_lRet     := .F.
-
+			For _nX := 1 to Len( aCols )
+				_cMsgnErro := ""
+				If !aCols[_nX][len(aHeader)+1] //Linha deletada
+					If AllTrim((aCols[_nX][_nLocOrig])) $ AllTrim(VAI->VAI_XESTOR)
+						_cMsgnErro += "Armazem Origem: "+Alltrim((aCols[_nX][_nLocOrig]) ) + CRLF            
+					EndIf 
+					If AllTrim((aCols[_nX][_nLocDest])) $ AllTrim(VAI->VAI_XESTDE)
+						_cMsgnErro += "Armazem Destino: "+Alltrim((aCols[_nX][_nLocDest]) ) + CRLF 
+					EndIf		
+					If !Empty(_cMsgnErro)
+						_lRet := .F.
+						ApMsgStop( "Usuário não pode realizar transferencia para:"+ CRLF + CRLF + "Linha: "+ Alltrim(Str(_nX)) + CRLF + "Produto: "+AllTrim((aCols[_nX][_nPrdOrig])) + CRLF + _cMsgnErro ,"Aviso... [ A261TOK ]" )
+						Exit
+					EndIf
 				EndIf
-				
-			EndIf
-		Next
+			Next
+		Else
+			_lRet := .F.
+			ApMsgAlert( "Informe o tipo de Bloqueio no Cad. de Equipe Tecnica.","Aviso... [ A261TOK ]" )
+		EndIf
+	Else	
+		_lRet := .F.
+		ApMsgAlert( "Usuário não cadastrado na Equipe Tecnica.","Aviso... [ A261TOK ]" )
 	EndIf
-    	
+	
+	RestArea(_aAreaVAI)
+
 Return(_lRet)

--- a/SIGAEST/Função/ZESTF010.prw
+++ b/SIGAEST/Função/ZESTF010.prw
@@ -15,28 +15,33 @@ User Function ZESTF010()
 Local lUserAut  := .F.
 Local _nX       := 0
 Local _lRet     := .F.
+Local _cEmp     := FWCodEmp()
 Private _nLocal
 
-lUserAut := U_ZGENUSER( RetCodUsr() ,"ZESTF010",.T.)
+	If _cEmp == "2010" //Executa o p.e. Anapolis.
+    	_lRet := .T.
+	Else
+		lUserAut := U_ZGENUSER( RetCodUsr() ,"ZESTF010",.T.)
 
-_cLocal   := aScan(aHeader,{|x|UPPER(Alltrim(x[2])) == "D3_LOCAL"}) 
+		_cLocal   := aScan(aHeader,{|x|UPPER(Alltrim(x[2])) == "D3_LOCAL"}) 
 
-	For _nX := 1 to Len(aCols)
-	
-	    If !aCols[_nX][len(aHeader)+1]
-		 
-			If aCols[_nX][_nLocal]$"32/33" 
+		For _nX := 1 to Len(aCols)
 		
-			   Alert("Saldo insuficiente no armazém "+Acols[_nX][_nLocal]+"!")
-               _lRet     := .F.
-
-            Else
-
-                _lRet     := .F.
-
-	   		EndIf
+			If !aCols[_nX][len(aHeader)+1]
 			
-		EndIf
-	Next
+				If aCols[_nX][_nLocal]$"32/33" 
+			
+				Alert("Saldo insuficiente no armazém "+Acols[_nX][_nLocal]+"!")
+				_lRet     := .F.
+
+				Else
+
+					_lRet     := .F.
+
+				EndIf
+				
+			EndIf
+		Next
+	EndIf
     	
 Return(_lRet)

--- a/SIGAEST/Função/ZESTF010.prw
+++ b/SIGAEST/Função/ZESTF010.prw
@@ -5,7 +5,7 @@
 @version  	P12.1.23
 @since  	14/07/2023
 @return  	NIL
-@obs        Ponto de entrada do MATA241
+@obs        Ponto de entrada do MATA261
 @project
 @history    Função chamada no P.E MT241TOK_PE
 */ 

--- a/SIGAEST/Função/ZESTF010.prw
+++ b/SIGAEST/Função/ZESTF010.prw
@@ -1,0 +1,42 @@
+#Include "Protheus.ch"
+
+/*/{Protheus.doc} ZESTF010
+@author 	Evandro Mariano
+@version  	P12.1.23
+@since  	14/07/2023
+@return  	NIL
+@obs        Ponto de entrada do MATA241
+@project
+@history    Função chamada no P.E MT241TOK_PE
+*/ 
+
+User Function ZESTF010()
+
+Local lUserAut  := .F.
+Local _nX       := 0
+Local _lRet     := .F.
+Private _nLocal
+
+lUserAut := U_ZGENUSER( RetCodUsr() ,"ZESTF010",.T.)
+
+_cLocal   := aScan(aHeader,{|x|UPPER(Alltrim(x[2])) == "D3_LOCAL"}) 
+
+	For _nX := 1 to Len(aCols)
+	
+	    If !aCols[_nX][len(aHeader)+1]
+		 
+			If aCols[_nX][_nLocal]$"32/33" 
+		
+			   Alert("Saldo insuficiente no armazém "+Acols[_nX][_nLocal]+"!")
+               _lRet     := .F.
+
+            Else
+
+                _lRet     := .F.
+
+	   		EndIf
+			
+		EndIf
+	Next
+    	
+Return(_lRet)


### PR DESCRIPTION
Fontes:
A261TOK_PE.prw 
MA261EST_PE.prw
MT240EST_PE.prw
MT241TOK_PE.prw
OA180VLD_PE.prw
ZESTF010.prw

Motivo: Todos usuários conseguem fazer movimentações internas e transferências em todos armazéns, sendo necessário bloquear as movimentações internas e transferências manuais para armazéns utilizados pelo sistema em todas as filiais da empresa 2020.

Melhoria: Desenvolvimento de programas específicos para bloquear o acesso a todos os usuários. Os usuários com permissão podem ser liberados no Cadastro Rotinas x Acessos (Caoa) no SIGACFG pelo administrador do sistema.