### PR TITLE
Integração | Autoware 100.002 | Correção na validação do Bloqueio de Cliente (#GAP047)

### DIFF
--- a/Integracoes/Autoware/Montadora/CMVAUT01.PRW
+++ b/Integracoes/Autoware/Montadora/CMVAUT01.PRW
@@ -216,7 +216,7 @@ SA1->(DbSetOrder(3))
 If SA1->(DbSeek(xFilial("SA1")+cWSCNPJ))
 	cCodCli := SA1->A1_COD
 	cLjCli  := SA1->A1_LOJA
-	if SA1->A1_MSBLQL == '2'
+	if SA1->A1_MSBLQL == '1'
 		Return {cWSPedido,"0","Cliente Bloqueado: " + cWSCNPJ , "" }
 	Endif
 Else


### PR DESCRIPTION
Foi verificado que erro na validação se o Cliente está Ativo ou Inativo.
onde o  campo A1_MSBLQL  for igual a 1 o cliente está Inativo e se for 2 ou vazio o cliente esta ativo

**Termo de Entraga**
[GAP047-Correção na validação do Bloqueio de Cliente.pdf](https://github.com/Caoa-Montadora-de-Veiculos-Ltda/Protheus/files/12147565/GAP047-Correcao.na.validacao.do.Bloqueio.de.Cliente.pdf)
