### PR TITLE
CHG0032627 | Integração | Autoware 100.003 | Ajuste no controle de numeração da Tabela SC5 (#GAP048)

### DIFF
--- a/Integracoes/Autoware/Montadora/CMVAUT01.PRW
+++ b/Integracoes/Autoware/Montadora/CMVAUT01.PRW
@@ -410,7 +410,15 @@ Begin Transaction
         (cTmpAlias)->(DbGoTop())
 
         If (cTmpAlias)->(!Eof())
-            cNumPed := GetSxeNum("SC5","C5_NUM")  
+            
+            cNumPed := GetSxeNum("SC5","C5_NUM")
+                        
+            WHILE ExistCpo("SC5", cNumPed , 1)   //Valido se a numeração já existe para evitar que use uma chave que já existe
+                ConfirmSX8()
+                cNumPed := GetSxeNum("SC5","C5_NUM")
+            ENDDO
+            ConfirmSX8() 
+            
             aCabPed := {}
             Aadd(aCabPed, {"C5_NUM"    ,cNumPed                 , Nil}); Aadd(aCabPed, {"C5_TIPO"   ,"N"                        , Nil})
             Aadd(aCabPed, {"C5_CLIENTE",(cTmpAlias)->VRJ_CODCLI , Nil}); Aadd(aCabPed, {"C5_LOJACLI",(cTmpAlias)->VRJ_LOJA      , Nil})


### PR DESCRIPTION
GAP048 | Ajuste no controle de numeração da Tabela SC5
Inclusão de controle de numeração, para verificar se o número do pedido já existe na tabela SC5 (Pedido de
Venda) e confirma sua utilização e pegando o próximo número disponível.

**Termo de Entrga** 
[GAP048 - Controle de Numeração na integração do Autoware..pdf](https://github.com/Caoa-Montadora-de-Veiculos-Ltda/Protheus/files/12152619/GAP048.-.Controle.de.Numeracao.na.integracao.do.Autoware.pdf)
