### PR TITLE
CHG0032716 | FIS004.002 | Ajuste da TES na integração Autoware

### DIFF
--- a/Ponto de Entrada/MT089CD_PE.prw
+++ b/Ponto de Entrada/MT089CD_PE.prw
@@ -80,9 +80,14 @@ Static Function zFMontadora()
 		endif
 		bIRWhile:= {||.T.}
 		bAddTes := {||aAdd(aTes[Len(aTes)],(cAliasSFM)->FM_XORIGEM)}//Acrescento campo a ser considerado na TES Inteligente. 
-	ElseIf cTabela == "" .And. FunName() == "VEIA060" 
-	
-		_nProd := FwFldGet("B1COD") 
+	ElseIf cTabela == "" .And. (FunName() == "VEIA060" .or. FunName() == 'RPC')
+		
+		if FunName() == "RPC"
+			_nProd    := SB1->B1_COD
+		else
+			_nProd    := FwFldGet("B1COD") 
+		endif
+		
 		bCond     := {|| SB1->B1_ORIGEM == (cAliasSFM)->FM_XORIGEM .Or. Empty((cAliasSFM)->FM_XORIGEM)  } 
 		
 		//Acrescenta compo novo a regra, esse campo devera ser acrescentdo no X2_UNICO do SFM. 


### PR DESCRIPTION
 Alterado o Ponto de Entrada MT089CD_PE.prw, para tratar a busca da TES da Integração do Autoware do mesmo modo que é tratado pela VEIA060.
Devido a origem do Veiculo ser 6-ESTR-IMPORT DIR,SEM SIMILAR NAC,CONSTA NA LISTA CAMEX, pois normalmente é utilizado a origem 0 - Nacional ou 1 - Importado, o qual o Protheus já estava preparado

**Termo de Entrega**
[GAP071 - TES Rede Importados.pdf](https://github.com/Caoa-Montadora-de-Veiculos-Ltda/Protheus/files/12352146/GAP071.-.TES.Rede.Importados.pdf)
