### PR TITLE
CHG0032784 | EIC002.003 | Incluir F4 na tela de eliminar saldo da Purchase Order

### DIFF
--- a/Ponto de Entrada/EICPO400_PE.prw
+++ b/Ponto de Entrada/EICPO400_PE.prw
@@ -53,7 +53,7 @@ user function EICPO400 ()
 			//SetKey (VK_F4,{||})
 
 		Case Paramixb == "ANTES_ELIMINA" 
- 			 etKey (VK_F4,{||U_ZEICF020()})
+ 			 SetKey (VK_F4,{||U_ZEICF020()})
 		
 	EndCase
 	

--- a/Ponto de Entrada/EICPO400_PE.prw
+++ b/Ponto de Entrada/EICPO400_PE.prw
@@ -51,6 +51,9 @@ user function EICPO400 ()
 
 		    SetKey (VK_F4,{||U_ZEICF020()})
 			//SetKey (VK_F4,{||})
+
+		Case Paramixb == "ANTES_ELIMINA" 
+ 			 etKey (VK_F4,{||U_ZEICF020()})
 		
 	EndCase
 	


### PR DESCRIPTION
Fonte: EICPO400_PE.PRW
Melhoria: Incluído a opção de F4 para quando o Paramixb for igual a "ANTES_ELIMINA"




	