### PR TITLE
CHG0032818 | EIC002.004 | Tipo de importação não está sendo preenchido em algumas Purchase Order de importação

### DIFF
--- a/SIGACOM/Função/CMVIMP01.prw
+++ b/SIGACOM/Função/CMVIMP01.prw
@@ -1951,7 +1951,7 @@ User function xExec(nOpc,xI,aAutoCab,aAutoDet,cEmpresa,aFil,cLogFile,dData,lGrid
 	Local nX := 0
 	//Local aLog := {}
 	Local bError	:= ErrorBlock( { |oError| MyError( oError ) } )
-	Local cLogDir	:= "\CMV\IMP\"
+	//Local cLogDir	:= "\CMV\IMP\"
 	Local cCodigo, cStatus, cAliasTRB
 
 	Private cError
@@ -2594,10 +2594,12 @@ User function MyExec(nOpc,aExecAuto,aExecAutod)
 			cClaImp	:=	Alltrim(aExecAuto[nClaImp,2])
 			cClaImp	:=	Stuff( Space( TamSX3("W2_XCLAIMP")[1] )	, 1 , Len(cClaImp) , cClaImp )
 			
-			 RecLock("SW2",.F.)
-			SW2->W2_XTIPIMP	:= cTipImp
-			SW2->W2_XCLAIMP	:= cClaImp
-			SW2->( msUnlock() )
+			if Emtpy(SW2->W2_XTIPIMP)
+				RecLock("SW2",.F.)
+					SW2->W2_XTIPIMP	:= cTipImp
+					SW2->W2_XCLAIMP	:= cClaImp
+				SW2->( msUnlock() )
+			EndIf
 		EndIf
 
 	ElseIf nOpc == 22

--- a/SIGAEIC/Funcao/GRVPO400.prw
+++ b/SIGAEIC/Funcao/GRVPO400.prw
@@ -47,11 +47,16 @@ User Function GRVPO400()
 				SW0->(DbSeek(xFilial("SW0") + SW3->W3_CC + SW3->W3_SI_NUM ) )
 				cTpImp := SW0->W0_TIPIMP
 				cCliImp:= SW0->W0_XCLAIMP
-
-				RecLock("SW2",.F.)
-					SW2->W2_XTIPIMP := cTpImp
-					SW2->W2_XCLAIMP := cCliImp
-				SW2->( MsUnlock() )
+				
+				M->W2_XTIPIMP:= cTpImp
+				M->W2_XCLAIMP := cCliImp
+				
+				if Empty(SW2->W2_XTIPIMP) .and. !Empty(cTpImp)
+					RecLock("SW2",.F.)
+						SW2->W2_XTIPIMP := cTpImp
+						SW2->W2_XCLAIMP := cCliImp
+					SW2->( MsUnlock() )
+				EndIf
 
 				cNumSI := SW3->W3_SI_NUM
 			EndIf
@@ -225,11 +230,16 @@ User Function xGRVP400()
 	If QSW3->(!Eof())
 		cTpImp := SW0->W0_TIPIMP
 		cCliImp:= SW0->W0_XCLAIMP
-
-		SW2->(RecLock("SW2",.F.))
-		SW2->W2_XTIPIMP := cTpImp
-		SW2->W2_XCLAIMP := cCliImp
-		SW2->(MsUnlock())
+		
+		M->W2_XTIPIMP:= cTpImp
+		M->W2_XCLAIMP := cCliImp
+		
+		if Empty(SW2->W2_XTIPIMP) .and. !empty(cTpImp)
+			SW2->(RecLock("SW2",.F.))
+				SW2->W2_XTIPIMP := cTpImp
+				SW2->W2_XCLAIMP := cCliImp
+			SW2->(MsUnlock())
+		EndIf
 
 		While QSW3->(!Eof())
 
@@ -354,11 +364,16 @@ User Function xGRVG400()
 		If SW0->(DbSeek(xFilial("SW0") + SW3->W3_CC + SW3->W3_SI_NUM ) )
 			cTpImp := SW0->W0_TIPIMP
 			cCliImp:= SW0->W0_XCLAIMP
+			
+			M->W2_XTIPIMP:= cTpImp
+			M->W2_XCLAIMP := cCliImp
 
-			RecLock("SW2",.F.)
-			SW2->W2_XTIPIMP := cTpImp
-			SW2->W2_XCLAIMP := cCliImp
-			SW2->( MsUnlock() )
+			if Empty(SW2->W2_XTIPIMP) .and. !empty(cTpImp)
+				RecLock("SW2",.F.)
+					SW2->W2_XTIPIMP := cTpImp
+					SW2->W2_XCLAIMP := cCliImp
+				SW2->( MsUnlock() )
+			EndIf
 		EndIf
 
 		While !SW3->(Eof()) .And. xFilial("SW3") + SW3->W3_PO_NUM == SW2->(W2_FILIAL + W2_PO_NUM)


### PR DESCRIPTION
Fonte: EICPO400_PE.prw
    Incluído ponto de entrada MVC "VAL_GRAVA_PO" o qual faz a validação antes da Gravação das Tabelas.
    O qual validará se o Tipo de Importação foi informado na Tabela SW0 o qual é replicado para a Tabela SW2.

Fonte : GRVPO400.PRW
    Incluído validação  se o campo da SW2 esta preenchido com o tipo de importação

Fonte : CMVIMP01.PRW
    Incluído validação  se o campo da SW2 esta preenchido com o tipo de importação

**Termo de Entrega** 
[GAP084 - Preenchimento do Tipo de importação na Purchase Order.pdf](https://github.com/Caoa-Montadora-de-Veiculos-Ltda/Protheus/files/12601874/GAP084.-.Preenchimento.do.Tipo.de.importacao.na.Purchase.Order.pdf)
