### PR TITLE
CHG0032836 | Integração | Autoware 001.003 | Ajuste nas condições da query do Tipo de Operação

### DIFF
--- a/SIGAPEC/Funcao/ZPECFUNA.PRW
+++ b/SIGAPEC/Funcao/ZPECFUNA.PRW
@@ -4001,8 +4001,8 @@ User Function zTpOper(_cCliente, _cLoja, _cTipoPed)
 		_cQuery += " WHERE "
 		_cQuery += " FM_FILIAL  = '"+xFilial("SFM")+"' AND "
 		_cQuery += " FM_CLIENTE = '"+_cCliente+"' AND "
-		_cQuery += " FM_LOJACLI = '"+_cLoja+"' OR (FM_EST = '"+_cUFCliente+"' AND FM_CLIENTE = ' ') AND "
-		_cQuery += " D_E_L_E_T_ = ' ' ORDER BY FM_CLIENTE DESC "
+		_cQuery += " FM_LOJACLI = '"+_cLoja+"' AND D_E_L_E_T_ = ' ' OR (FM_EST = '"+_cUFCliente+"' AND FM_CLIENTE = ' ')"
+		_cQuery += " ORDER BY FM_CLIENTE DESC "
 		dbUseArea( .T., "TOPCONN", TcGenQry(,,_cQuery), _cAliasSFM, .T., .T. )
 
 		(_cAliasSFM)->(dbGoTop())


### PR DESCRIPTION
Fonte: ZPECFUNA.PRW
Erro: Orçamentos do cliente 000229 01 entrando com operação 091
Objetivo: Corrigir query de TES inteligente para não considerar deletados