### PR TITLE
CHG0033088 | FIS002.003 | Correção no Calculo do valor do item

### DIFF
--- a/SIGAFIS/Relatorio/ZFISR001.prw
+++ b/SIGAFIS/Relatorio/ZFISR001.prw
@@ -49,10 +49,11 @@ Static Function zSelect(nRadio)
 	Local cArquivo	:= ""
 	Private cPergR1	:= "ZFISR001R1"
 	Private cPergR2	:= "ZFISR001R2"
+	Private lMvNFLeiZF := SuperGetMV("MV_NFLEIZF",,.F.)
 
 	If nRadio == 1
 		If Pergunte( cPergR1	,.T.	)
-			cArquivo := cGetFile( cExtens		,cTitulo	,				,cMainPath		,.F.		,)
+			cArquivo := cGetFile(cExtens,cTitulo,,cMainPath,.F.,)
 			If !Empty(cArquivo)
 				Processa({|| zRel0001(cArquivo)}	,"Gerando Relatório de Notas Fiscais de Entrada..."	)
 			EndIf
@@ -116,6 +117,7 @@ Static Function zRel0001(cArquivo)
 	Local cCodNatur		:= ""
 	Local cCodChassi	:= ""
 	Local nVlCom		:= 0
+	Local nTotal 		:= 0
 
 	If !ApOleClient( "MSExcel" )
 		MsgAlert( "Microsoft Excel não instalado!!" )
@@ -251,11 +253,10 @@ Static Function zRel0001(cArquivo)
 
 	If !Empty( MV_PAR18 )
 		cQuery += " 	AND SD1.D1_CF = '" + MV_PAR18 + "' " 																		+ CRLF
-	EndIf  
+	EndIf
 
-
-    If !Empty( MV_PAR23) .OR. !Empty( MV_PAR24 )
-	   cQuery += " 	AND SD1.D1_CHASSI BETWEEN '" + MV_PAR23 + "' AND '" + MV_PAR24 + "' " 												+ CRLF
+    If !Empty( MV_PAR22) .OR. !Empty( MV_PAR23 )
+	   cQuery += " 	AND SD1.D1_CHASSI BETWEEN '" + MV_PAR22 + "' AND '" + MV_PAR23 + "' " 												+ CRLF
     EndIf
 
 	cQuery += " GROUP BY 	D1_FILIAL, D1_COD, D1_DOC, D1_SERIE, D1_TES, D1_CF, D1_FORNECE, D1_LOJA, D1_EMISSAO, D1_DTDIGIT, " 		+ CRLF
@@ -656,6 +657,12 @@ Static Function zRel0001(cArquivo)
 			zRel0003(@nVlIPIRegi, @nVlIPIPres, (cAliasTRB)->F1_ESPECIE, (cAliasTRB)->F1_DOC, (cAliasTRB)->F1_SERIE,;
 					(cAliasTRB)->D1_FORNECE, (cAliasTRB)->D1_LOJA, (cAliasTRB)->D1_ITEM )
 
+			if !lMvNFLeiZF
+				nTotal := (cAliasTRB)->D1_TOTAL  
+			Else
+                nTotal := (cAliasTRB)->D1_TOTAL - ((cAliasTRB)->D1_DESCZFP + (cAliasTRB)->D1_DESCZFC) //--Valor Total Item
+			EndIF
+			
 			oFWMSExcel:AddRow( cAba1	,cTabela1	,{ 	cCgcCpf,;    //--Cnpj/Cpf 
 														cIncEst,;    //--Insc.Estadual
 														cTpPessoa,;    //--Pessoa Fisica/Juridica
@@ -664,12 +671,12 @@ Static Function zRel0001(cArquivo)
 														Alltrim( (cAliasTRB)->F4_FINALID ),;    //--Finalidade TES
 														AllTrim( (cAliasTRB)->B1_ORIGEM ),;    //--Origem do Produto
 														AllTrim( (cAliasTRB)->B1_POSIPI ),;    //--NCM
-														AllTrim( (cAliasTRB)->B1_EX_NCM ),;    //--Ex-NBM
+														AllTrim( (cAliasTRB)->B1_EX_NCM ),;    //--Ex-NCM
 														AllTrim( cModVei ),;    //--Modelo Veículo
 														AllTrim( (cAliasTRB)->VRK_OPCION ),;    //--Opcional
 														AllTrim( (cAliasTRB)->B1_GRUPO ),;    //--Grupo\Linha
 														AllTrim( Posicione("SBM",1,xFilial("SBM")+(cAliasTRB)->B1_GRUPO,"BM_DESC") ),;    //--Descrição do Grupo
-														(cAliasTRB)->D1_TOTAL,;    //--Valor Total Item
+														nTotal ,; //(cAliasTRB)->D1_TOTAL,;    //--Valor Total Item
 														(cAliasTRB)->D1_CF,;    //--Cfop
 														(cAliasTRB)->FT_VALCONT,;    //--Valor Contábil
 														(cAliasTRB)->FT_BASEICM,;    //--Base ICMS
@@ -892,7 +899,6 @@ Static Function zRel0001(cArquivo)
 			oFWMsExcel:AddColumn( cAba2	,cTabela2	,"Chave NFe"			,2	,1	,.F.	) // Center - Texto
 			oFWMsExcel:AddColumn( cAba2	,cTabela2	,"Descrição"			,2	,1	,.F.	) // Center - Texto
 
-
 			While (cTMPCanc)->(!EoF())
 				
 				oFWMSExcel:AddRow( cAba2	, cTabela2	, { Alltrim( (cTMPCanc)->F3_FILIAL ),;    //--Empresa
@@ -992,7 +998,9 @@ Static Function zRel0002(cArquivo)
 	Local nTotReg		:= ""
 	Local nVlIPIRegi	:= 0
 	Local nVlIPIPres	:= 0
-	
+	Local nDesconto		:= 0
+	Local nDesVrIcms	:= 0
+	Local nTotal		:= 0
 
 	If !ApOleClient("MSExcel")
 		MsgAlert("Microsoft Excel não instalado!")
@@ -1008,7 +1016,7 @@ Static Function zRel0002(cArquivo)
 	cQuery += " B1_DESC, B1_XDESCL1, B1_GRUPO, B1_POSIPI, B1_CEST, B1_ORIGEM, B1_EX_NCM, D2_ITEM, "							+ CRLF
 	cQuery += " F2_ESPECIE,F2_CODNFE,F2_MENNOTA,F2_USERLGI,F2_USERLGA,F2_TIPO, FT_CHVNFE,F2_DOC, F2_SERIE, F2_FIMP,  " 		+ CRLF
 	cQuery += " FT_VALCONT, FT_DESCONT, F2_FORMUL, D2_CONTA, D2_NFORI, D2_SERIORI, D2_PRUNIT,D2_TOTAL, "					+ CRLF
-	cQuery += " D2_DESC, FT_CLASFIS, D2_DESCZFP, D2_DESCZFC, D2_TIPO, "														+ CRLF
+	cQuery += " D2_DESC, FT_CLASFIS, D2_DESCZFP, D2_DESCZFC, D2_TIPO, D2_DESCON,"														+ CRLF
 	cQuery += " FT_BASEICM, FT_ALIQICM, FT_VALICM, C6_CHASSI, "																+ CRLF
 	cQuery += " FT_BASEIPI, FT_ALIQIPI, FT_VALIPI, FT_ARETPIS, FT_ARETCOF, FT_VRETPIS, FT_VRETCOF, FT_BRETPIS, "			+ CRLF
 	cQuery += " FT_BASERET, FT_ICMSRET, FT_DIFAL, FT_BRETCOF, "																+ CRLF
@@ -1020,7 +1028,7 @@ Static Function zRel0002(cArquivo)
 	cQuery += " FT_BASEINS,FT_ALIQINS,D2_ABATINS,FT_VALINS, D2_UM, D2_QUANT, "												+ CRLF
 	cQuery += " D2_BASEISS,D2_ALIQISS,D2_ABATISS,D2_ABATMAT,D2_VALISS, D2_ITEMCC, "											+ CRLF
 	cQuery += " FT_BASECSL,FT_ALIQCSL,FT_VALCSL, D2_CUSTO1, VRK_CHASSI, VRJ_CODCLI, VRJ_LOJA, C6_XVLCOM, "					+ CRLF
-	cQuery += " C6_TNATREC, C6_NFORI, C6_FILIAL, C6_NUM, VV3_TIPVEN, VV3_DESCRI, VRJ_CLIRET, VRK_OPCION "					+ CRLF
+	cQuery += " C6_TNATREC, C6_NFORI, C6_FILIAL, C6_NUM, VV3_TIPVEN, VV3_DESCRI, VRJ_CLIRET, VRK_OPCION,D2_DESCZFR , D2_VRDICMS " + CRLF
 	cQuery += " FROM   " + RetSQLName("SD2") + " SD2 " 																		+ CRLF
 	
 	cQuery += "	INNER JOIN " + RetSQLName("SF2") + " SF2 "																+ CRLF
@@ -1128,7 +1136,7 @@ Static Function zRel0002(cArquivo)
 	cQuery += " B1_DESC, B1_XDESCL1, B1_GRUPO, B1_POSIPI, B1_CEST, B1_ORIGEM, B1_EX_NCM, D2_ITEM, "							+ CRLF
 	cQuery += " F2_ESPECIE,F2_CODNFE,F2_MENNOTA,F2_USERLGI,F2_USERLGA,F2_TIPO, FT_CHVNFE,F2_DOC, F2_SERIE, F2_FIMP,  " 		+ CRLF
 	cQuery += " FT_VALCONT, FT_DESCONT, F2_FORMUL, D2_CONTA, D2_NFORI, D2_SERIORI, D2_PRUNIT,D2_TOTAL, "					+ CRLF
-	cQuery += " D2_DESC, FT_CLASFIS, D2_DESCZFP, D2_DESCZFC, D2_TIPO, "														+ CRLF
+	cQuery += " D2_DESC, FT_CLASFIS, D2_DESCZFP, D2_DESCZFC, D2_TIPO,D2_DESCON, "														+ CRLF
 	cQuery += " FT_BASEICM, FT_ALIQICM, FT_VALICM, C6_CHASSI, "																+ CRLF
 	cQuery += " FT_BASEIPI, FT_ALIQIPI, FT_VALIPI, FT_ARETPIS, FT_ARETCOF, FT_VRETPIS, FT_VRETCOF, FT_BRETPIS, "			+ CRLF
 	cQuery += " FT_BASERET, FT_ICMSRET, FT_DIFAL, FT_BRETCOF, "																+ CRLF
@@ -1140,7 +1148,7 @@ Static Function zRel0002(cArquivo)
 	cQuery += " FT_BASEINS,FT_ALIQINS,D2_ABATINS,FT_VALINS, D2_UM, D2_QUANT, "												+ CRLF
 	cQuery += " D2_BASEISS,D2_ALIQISS,D2_ABATISS,D2_ABATMAT,D2_VALISS, D2_ITEMCC, "											+ CRLF
 	cQuery += " FT_BASECSL,FT_ALIQCSL,FT_VALCSL, D2_CUSTO1, VRK_CHASSI, VRJ_CODCLI, VRJ_LOJA, C6_XVLCOM,  "					+ CRLF
-	cQuery += " C6_TNATREC, C6_NFORI, C6_FILIAL, C6_NUM, VV3_TIPVEN, VV3_DESCRI, VRJ_CLIRET, VRK_OPCION "					+ CRLF
+	cQuery += " C6_TNATREC, C6_NFORI, C6_FILIAL, C6_NUM, VV3_TIPVEN, VV3_DESCRI, VRJ_CLIRET, VRK_OPCION,D2_DESCZFR, D2_VRDICMS"					+ CRLF
 
 	cQuery += " ORDER BY SD2.D2_FILIAL, SD2.D2_DOC, SD2.D2_SERIE, SD2.D2_CLIENTE, SD2.D2_LOJA " 						+ CRLF
 
@@ -1152,7 +1160,7 @@ Static Function zRel0002(cArquivo)
 	DbSelectArea((cAliasTRB))
 	nTotReg := Contar(cAliasTRB,"!Eof()")
 	(cAliasTRB)->(dbGoTop())
-	
+
 	If (cAliasTRB)->(!Eof())
 
 		// Criando o objeto que irá gerar o conteúdo do Excel.
@@ -1174,7 +1182,7 @@ Static Function zRel0002(cArquivo)
 		oFWMsExcel:AddColumn( cAba1	,cTabela1	,"Finalidade TES"				,1	,1	,.F.	) // Left - Texto
 		oFWMsExcel:AddColumn( cAba1	,cTabela1	,"Origem do Produto"			,1	,1	,.F.	) // Left - Texto
 		oFWMsExcel:AddColumn( cAba1	,cTabela1	,"NCM"							,1	,1	,.F.	) // Left - Texto
-		oFWMsExcel:AddColumn( cAba1	,cTabela1	,"Ex-NCM"						,1	,1	,.F.	) // Left - Texto
+		oFWMsExcel:AddColumn( cAba1	,cTabela1	,"Ex-NBM"						,1	,1	,.F.	) // Left - Texto
 		oFWMsExcel:AddColumn( cAba1	,cTabela1	,"Modelo Veículo"				,1	,1	,.F.	) // Left - Texto
 		oFWMsExcel:AddColumn( cAba1	,cTabela1	,"Opcional"						,1	,1	,.F.	) // Left - Texto
 		oFWMsExcel:AddColumn( cAba1	,cTabela1	,"Grupo\Linha"					,1	,1	,.F.	) // Left - Texto
@@ -1518,142 +1526,154 @@ Static Function zRel0002(cArquivo)
 			nVlIPIPres := 0
 			//-- Retorna Valor de IPI regional e presumido
 			zRel0003(@nVlIPIRegi, @nVlIPIPres, (cAliasTRB)->F2_ESPECIE, (cAliasTRB)->F2_DOC, (cAliasTRB)->F2_SERIE,;
-					(cAliasTRB)->D2_CLIENTE, (cAliasTRB)->D2_LOJA, (cAliasTRB)->D2_ITEM )	
+					(cAliasTRB)->D2_CLIENTE, (cAliasTRB)->D2_LOJA, (cAliasTRB)->D2_ITEM )
 
-			oFWMSExcel:AddRow( cAba1	, cTabela1	, { cCgcCpf,;    //--Cnpj/Cpf
-														cCGCLocEnt,;    //--CNPJ Loc. Entr.
-														cIncEst,;    //--Insc.Estadual
-														cTpPessoa,;    //--Pessoa Fisica/Juridica
-														cEstCli,;    //--UF
+			nDesconto   := (cAliasTRB)->D2_DESCON
+        	nDesVrIcms  := 0
+			If  (cAliasTRB)->D2_VRDICMS > 0  .and. nDesconto >= (cAliasTRB)->D2_VRDICMS 
+				nDesVrIcms := (cAliasTRB)->D2_VRDICMS
+			EndIF
+        
+        	if !lMvNFLeiZF
+				nTotal := ((cAliasTRB)->D2_TOTAL  + nDesconto + (cAliasTRB)->D2_DESCZFR ) - nDesVrIcms 
+			Else
+                nTotal := ((cAliasTRB)->D2_TOTAL  + nDesconto + (cAliasTRB)->D2_DESCZFR ) - ( (cAliasTRB)->D2_DESCZFP + (cAliasTRB)->D2_DESCZFC + nDesVrIcms )  //--Valor Total Item
+			EndIF
+      
+			oFWMSExcel:AddRow( cAba1	, cTabela1	, { cCgcCpf,;                //--Cnpj/Cpf
+														cCGCLocEnt,;             //--CNPJ Loc. Entr.
+														cIncEst,;                //--Insc.Estadual
+														cTpPessoa,;              //--Pessoa Fisica/Juridica
+														cEstCli,;                //--UF
 														(cAliasTRB)->D2_TES,;    //--Tes
 														Alltrim( (cAliasTRB)->F4_FINALID ),;    //--Finalidade TES
-														AllTrim( (cAliasTRB)->B1_ORIGEM ),;    //--Origem do Produto
-														AllTrim( (cAliasTRB)->B1_POSIPI ),;    //--NCM
-														AllTrim( (cAliasTRB)->B1_EX_NCM ),;    //--Ex-NBM
-														AllTrim( cModVei ),;    //--Modelo Veículo
+														AllTrim( (cAliasTRB)->B1_ORIGEM ),;     //--Origem do Produto
+														AllTrim( (cAliasTRB)->B1_POSIPI ),;     //--NCM
+														AllTrim( (cAliasTRB)->B1_EX_NCM ),;     //--Ex-NBM
+														AllTrim( cModVei ),;                    //--Modelo Veículo
 														AllTrim( (cAliasTRB)->VRK_OPCION ),;    //--Opcional
-														AllTrim( (cAliasTRB)->B1_GRUPO ),;    //--Grupo\Linha
+														AllTrim( (cAliasTRB)->B1_GRUPO ),;      //--Grupo\Linha
 														AllTrim( Posicione("SBM",1,xFilial("SBM")+(cAliasTRB)->B1_GRUPO,"BM_DESC") ),;    //--Descrição do Grupo
-														(cAliasTRB)->D2_TOTAL,;    //--Valor Total Item
-														(cAliasTRB)->D2_CF,;    //--Cfop
+														nTotal,;    //--Valor Total Item
+														(cAliasTRB)->D2_CF,;         //--Cfop
 														(cAliasTRB)->FT_VALCONT,;    //--Valor Contábil
-														(cAliasTRB)->FT_BASEICM,;    //--Base ICMS
-														(cAliasTRB)->FT_ALIQICM,;    //--Aliq. ICMS
-														(cAliasTRB)->FT_VALICM,;    //--Valor ICMS
-														(cAliasTRB)->C6_XVLCOM,;    //--Comissão
+														iif( Alltrim((cAliasTRB)->F2_ESPECIE) <> "RPS", (cAliasTRB)->FT_BASEICM , 0),;    //--Base ICMS
+														iif( Alltrim((cAliasTRB)->F2_ESPECIE) <> "RPS", (cAliasTRB)->FT_ALIQICM , 0),;    //--Aliq. ICMS
+														iif( Alltrim((cAliasTRB)->F2_ESPECIE) <> "RPS", (cAliasTRB)->FT_VALICM  , 0), ;     //--Valor ICMS
+														(cAliasTRB)->C6_XVLCOM,;     //--Comissão
 														(cAliasTRB)->FT_BASEIPI,;    //--Base IPI
 														(cAliasTRB)->FT_ALIQIPI,;    //--Aliq. IPI
-														(cAliasTRB)->FT_VALIPI,;    //--Valor IPI
-														nVlIPIRegi,;    //--Credito_Regional IPI
-														nVlIPIPres,;    //--Credito_Presumido IPI/Frete
+														(cAliasTRB)->FT_VALIPI,;     //--Valor IPI
+														nVlIPIRegi,;                 //--Credito_Regional IPI
+														nVlIPIPres,;                 //--Credito_Presumido IPI/Frete
 														(cAliasTRB)->FT_BASERET,;    //--Base Subst
 														(cAliasTRB)->FT_ICMSRET,;    //--Valor Subst
 														(cAliasTRB)->FT_BASEPIS,;    //--Base Pis Apuração
 														(cAliasTRB)->FT_ALIQPIS,;    //--Aliq. Pis Apuração
-														(cAliasTRB)->FT_VALPIS,;    //--Valor Pis Apuração
+														(cAliasTRB)->FT_VALPIS,;     //--Valor Pis Apuração
 														(cAliasTRB)->FT_BASECOF,;    //--Base Cofins Apuração
-														(cAliasTRB)->FT_ALIQCOF,;	//--Aliq. Cofins Apuração
-														(cAliasTRB)->FT_VALCOF,;	//--Valor Cofins Apuração
+														(cAliasTRB)->FT_ALIQCOF,;	 //--Aliq. Cofins Apuração
+														(cAliasTRB)->FT_VALCOF,;	 //--Valor Cofins Apuração
 														(cAliasTRB)->FT_BASEPS3,;    //--Base Pis ST ZFM
 														(cAliasTRB)->FT_ALIQPS3,;    //--Aliq. Pis ST ZFM
-														(cAliasTRB)->FT_VALPS3,;	//--Vl. Pis ST ZFM
+														(cAliasTRB)->FT_VALPS3,;	 //--Vl. Pis ST ZFM
 														(cAliasTRB)->FT_BASECF3,;    //--Base Cof ST ZFM
 														(cAliasTRB)->FT_ALIQCF3,;    //--Aliq. Cof ST ZFM
-														(cAliasTRB)->FT_VALCF3,;	//--Vl. Cof ST ZFM
-														(cAliasTRB)->FT_DIFAL,;    //--ICMS Difal
+														(cAliasTRB)->FT_VALCF3,;	 //--Vl. Cof ST ZFM
+														(cAliasTRB)->FT_DIFAL,;      //--ICMS Difal
 														(cAliasTRB)->FT_CLASFIS,;    //--CST ICMS
-														(cAliasTRB)->FT_CTIPI,;    //--CST IPI
-														(cAliasTRB)->FT_CSTPIS,;    //--CST PIS
-														(cAliasTRB)->FT_CSTCOF,;    //--CST COFINS
-														(cAliasTRB)->F4_ICM,;    //--Calcula ICMS
+														(cAliasTRB)->FT_CTIPI,;      //--CST IPI
+														(cAliasTRB)->FT_CSTPIS,;     //--CST PIS
+														(cAliasTRB)->FT_CSTCOF,;     //--CST COFINS
+														(cAliasTRB)->F4_ICM,;        //--Calcula ICMS
 														(cAliasTRB)->F4_CREDICM,;    //--Credita ICMS
-														(cAliasTRB)->F4_IPI,;    //--Calcula IPI
+														(cAliasTRB)->F4_IPI,;        //--Calcula IPI
 														(cAliasTRB)->F4_CREDIPI,;    //--Credita IPI
-														(cAliasTRB)->D2_DOC,;    //--Nota Fiscal
+														(cAliasTRB)->D2_DOC,;        //--Nota Fiscal
 														IIF( AllTrim( (cAliasTRB)->F2_ESPECIE ) == 'NFS', (cAliasTRB)->D2_DOC, ""),;    //--Nf. Prefeitura
-														(cAliasTRB)->D2_SERIE,;    //--Série
+														(cAliasTRB)->D2_SERIE,;      //--Série
 														(cAliasTRB)->F2_ESPECIE,;    //--Espécie
-														AModNot( (cAliasTRB)->F2_ESPECIE ),;    //--Modelo
+														AModNot( (cAliasTRB)->F2_ESPECIE ),;     //--Modelo
 														IIF( Empty( SToD( (cAliasTRB)->D2_EMISSAO ) ), "", SToD( (cAliasTRB)->D2_EMISSAO ) ),;    //--Dt. de Emissão
 														(cAliasTRB)->D2_CLIENTE,;    //--Cliente\Fornecedor
-														(cAliasTRB)->D2_LOJA,;    //--Loja
-														cCliFor,;    //--Nome
-														AllTrim( (cAliasTRB)->C6_CHASSI ),;    //--Chassi
-														(cAliasTRB)->D2_COD,;    //--Cód.Produto
+														(cAliasTRB)->D2_LOJA,;       //--Loja
+														cCliFor,;                    //--Nome
+														AllTrim( (cAliasTRB)->C6_CHASSI ),;      //--Chassi
+														(cAliasTRB)->D2_COD,;        //--Cód.Produto
 														Substr( (cAliasTRB)->B1_DESC,1,20 ),;    //--Descrição do Produto
 														AllTrim( Posicione("SB5",1,xFilial("SB5")+(cAliasTRB)->D2_COD,"B5_CEME") ),;    //--Descrição Científico
 														AllTrim( (cAliasTRB)->B1_XDESCL1 ),;    //--Descrição Longa
-														(cAliasTRB)->D2_UM,;    //--Un Medida
-														(cAliasTRB)->D2_QUANT,;    //--Quant
-														(cAliasTRB)->D2_PRUNIT,;    //--Valor Unit. Item
+														(cAliasTRB)->D2_UM,;         //--Un Medida
+														(cAliasTRB)->D2_QUANT,;      //--Quant
+														(cAliasTRB)->D2_PRUNIT,;     //--Valor Unit. Item
 														(cAliasTRB)->FT_DESCONT,;    //--Desconto Item
-														nVlrFrete,;    //--Frete
+														nVlrFrete,;     //--Frete
 														nVlrSeguro,;    //--Seguro
-														nVlrDesp,;    //--Despesas
-														(cAliasTRB)->D2_CUSTO1,;    //--Custo
-														(cAliasTRB)->D2_CONTA,;    //--Conta Contábil
+														nVlrDesp,;      //--Despesas
+														(cAliasTRB)->D2_CUSTO1,;     //--Custo
+														(cAliasTRB)->D2_CONTA,;      //--Conta Contábil
 														AllTrim( Posicione("CT1",1,xFilial("CT1")+(cAliasTRB)->D2_CONTA,"CT1_DESC01") ),;    //--Desc.Conta Contábil
 														AllTrim( (cAliasTRB)->D2_FILIAL ),;    //--Empresa
-														cSituacao,;    //--Situação
-														cTpNF,;    //--Tipo Nota Fiscal
-														(cAliasTRB)->FT_CHVNFE,;    //--Chave Nota Fiscal
-														cProtocolo,;    //--Protocolo
+														cSituacao,;                  //--Situação
+														cTpNF,;                      //--Tipo Nota Fiscal
+														(cAliasTRB)->FT_CHVNFE,;     //--Chave Nota Fiscal
+														cProtocolo,;                 //--Protocolo
 														AllTrim( (cAliasTRB)->D2_NFORI ) + " - " + AllTrim( (cAliasTRB)->D2_SERIORI ),;    //--Nota Fiscal Origem
-														cDescTipo,;    //--Tipo Cli\For
-														cTpCliFor,;    //--Cli\For
+														cDescTipo,;                  //--Tipo Cli\For
+														cTpCliFor,;                  //--Cli\For
 														AllTrim( Posicione("SX5" ,1 ,xFilial("SX5") + "12" + cEstCli,"X5_DESCRI") ) ,;    //--Estado
 														AllTrim( Posicione("CC2" ,1 ,xFilial("CC2") + cEstCli + PadR( cCodMun ,TamSx3("CC2_CODMUN")[1] ) , "CC2_MUN" ) ),;    //--Município
-														AllTrim( (cAliasTRB)->B1_CEST ),;    //--CEST
-														AllTrim( cDesMod ),;    //--Descr. Modelo Veículo
-														AllTrim( cComVei ),;    //--Combustível Veículo
+														AllTrim( (cAliasTRB)->B1_CEST ),;     //--CEST
+														AllTrim( cDesMod ),;         //--Descr. Modelo Veículo
+														AllTrim( cComVei ),;         //--Combustível Veículo
 														AllTrim( (cAliasTRB)->F4_TEXTO ),;    //--Descrição CFOP
-														(cAliasTRB)->F2_CODNFE,;    //--Cód.Verificação
-														cAmbiente,;    //--Ambiente
+														(cAliasTRB)->F2_CODNFE,;     //--Cód.Verificação
+														cAmbiente,;    				 //--Ambiente
 														(cAliasTRB)->FT_BASEIRR,;    //--Base Irrf Retenção
 														(cAliasTRB)->FT_ALIQIRR,;    //--Aliq. Irrf Retenção
-														(cAliasTRB)->FT_VALIRR,;    //--Irrf Retenção
+														(cAliasTRB)->FT_VALIRR,;     //--Irrf Retenção
 														(cAliasTRB)->FT_BASEINS,;    //--Base Inss
 														(cAliasTRB)->FT_ALIQINS,;    //--Aliq. Inss
 														(cAliasTRB)->D2_ABATINS,;    //--Inss Recolhido
-														(cAliasTRB)->FT_VALINS,;    //--Valor Inss
+														(cAliasTRB)->FT_VALINS,;     //--Valor Inss
 														(cAliasTRB)->D2_BASEISS,;    //--Base Iss
 														(cAliasTRB)->D2_ALIQISS,;    //--Aliq. Iss
 														(cAliasTRB)->D2_ABATISS,;    //--Iss Serviços
 														(cAliasTRB)->D2_ABATMAT,;    //--Iss Materiais
-														(cAliasTRB)->D2_VALISS,;	//--Valor Iss
+														(cAliasTRB)->D2_VALISS,;	 //--Valor Iss
 														(cAliasTRB)->FT_BASECSL,;    //--Base Csll
 														IIF( (cAliasTRB)->FT_BASECSL > 0, (cAliasTRB)->FT_ALIQCSL, 0 ),;    //--Aliq. Csll
-														(cAliasTRB)->FT_VALCSL,;    //--Valor Csll
+														(cAliasTRB)->FT_VALCSL,;     //--Valor Csll
 														(cAliasTRB)->FT_BRETPIS,;    //--Base Pis Retenção
 														IIF( (cAliasTRB)->FT_BRETPIS > 0, (cAliasTRB)->FT_ARETPIS, 0 ),;    //--Aliq. Pis Retenção
 														(cAliasTRB)->FT_VRETPIS,;    //--Valor Pis Retenção
 														(cAliasTRB)->FT_BRETCOF,;    //--Base Cofins Retenção
 														IIF( (cAliasTRB)->FT_BRETCOF > 0, (cAliasTRB)->FT_ARETCOF, 0 ),;    //--Aliq. Cofins Retenção
 														(cAliasTRB)->FT_VRETCOF,;    //--Valor Cofins Retenção
-														cLogInc,;    //--Log. de Inclusão
-													  	cLogAlt,;    //--Log. de Alteração
-														cDtLogAlt,;    //--Dt. Log. de Alteração
+														cLogInc,;                    //--Log. de Inclusão
+													  	cLogAlt,;                    //--Log. de Alteração
+														cDtLogAlt,;                  //--Dt. Log. de Alteração
 														AllTrim( (cAliasTRB)->VV3_TIPVEN ),;    //--Tipo Venda
 														AllTrim( (cAliasTRB)->VV3_DESCRI ),;    //--Descr. Tipo Venda
-														cNumPed,;    //--Num. Pedido
-														cNaturez,;    //--Natureza Financeira
+														cNumPed,;                    //--Num. Pedido
+														cNaturez,;                   //--Natureza Financeira
 														AllTrim( (cAliasTRB)->C6_TNATREC ),;    //--Tab. Nat. Receita
-														AllTrim( (cAliasTRB)->D2_ITEMCC ),;    //--Item Contábil
+														AllTrim( (cAliasTRB)->D2_ITEMCC ),;     //--Item Contábil
 														(cAliasTRB)->F3_ISENICM,;    //--ICMS Isento
 														(cAliasTRB)->F3_OUTRICM,;    //--ICMS Outros
 														(cAliasTRB)->F3_ISENIPI,;    //--IPI Isento
 														(cAliasTRB)->F3_OUTRIPI,;    //--IPI Outros
-														cTransp,;    //--Cód. Transportadora
-														(cAliasTRB)->VRJ_CLIRET,; //--Cat. Local de Entrega
-														cNomLocEnt,;    //--Nome Loc. Entr.
-														cUFLocEnt,;    //--UF Loc. Entr.
-														cMsgSefaz,;    //--Msgn Sefaz
+														cTransp,;                    //--Cód. Transportadora
+														(cAliasTRB)->VRJ_CLIRET,;    //--Cat. Local de Entrega
+														cNomLocEnt,;                 //--Nome Loc. Entr.
+														cUFLocEnt,;                  //--UF Loc. Entr.
+														cMsgSefaz,;                  //--Msgn Sefaz
 														(cAliasTRB)->F2_MENNOTA,;    //--Msgn Nota Fiscal   
-														cMenNota,;    //--Mens.p/Nota
-														cMenPad,;    //--Mens. Padrão
-														cMensNFS,;   //--Mensagem NFS	
-														(cAliasTRB)->( F2_TOTFED + F2_TOTEST ),;	//--Vlr. Aprox. dos Tributos	
-														Alltrim( (cAliasTRB)->F4_DUPLIC ) })	//--Gera Duplicata   												    
+														cMenNota,;                   //--Mens.p/Nota
+														cMenPad,;                    //--Mens. Padrão
+														cMensNFS,;                   //--Mensagem NFS	
+														(cAliasTRB)->( F2_TOTFED + F2_TOTEST ),;  //--Vlr. Aprox. dos Tributos	
+														Alltrim( (cAliasTRB)->F4_DUPLIC ) })	  //--Gera Duplicata   												    
 			(cAliasTRB)->(DbSkip())
 		EndDo
 

--- a/SIGAFIS/Relatorio/ZFISR005.prw
+++ b/SIGAFIS/Relatorio/ZFISR005.prw
@@ -3,21 +3,22 @@
 
 //----------------------------------------------------------
 User Function ZFISR005()
-    Local oReport,  oSection
-
-    Private cAliasTMP := GetNextAlias()
-
+    Local oReport
+    Local oSection
+    Private cAliasTMP  := GetNextAlias()
+    Private lMvNFLeiZF := SuperGetMV("MV_NFLEIZF",,.F.)
+    
 	oReport:= TReport():New("ZFISR005",;
                             "Saidas",;
                             "ZFISR001R2",;
                             {|oReport|  ReportPrint(oReport)},;
                             "Este relatorio efetua a impressão das notas fiscais de saida")
-	oReport:HideParamPage()   // Desabilita a impressao da pagina de parametros.
-    oReport:HideHeader() //--Define que não será impresso o cabeçalho padrão da página
-    oReport:HideFooter() //--Define que não será impresso o rodapé padrão da página
-    oReport:SetDevice(4) //--Define o tipo de impressão selecionado. Opções: 1-Arquivo,2-Impressora,3-Email,4-Planilha, 5-Html e 6-PDF
-    oReport:SetPreview(.T.) //--Define se será apresentada a visualização do relatório antes da impressão física
-    oReport:SetEnvironment(2) //--Define o ambiente para impressão 	Ambiente: 1-Server e 2-Client
+	oReport:HideParamPage()     // Desabilita a impressao da pagina de parametros.
+    oReport:HideHeader()        //--Define que não será impresso o cabeçalho padrão da página
+    oReport:HideFooter()        //--Define que não será impresso o rodapé padrão da página
+    oReport:SetDevice(4)        //--Define o tipo de impressão selecionado. Opções: 1-Arquivo,2-Impressora,3-Email,4-Planilha, 5-Html e 6-PDF
+    oReport:SetPreview(.T.)     //--Define se será apresentada a visualização do relatório antes da impressão física
+    oReport:SetEnvironment(2)   //--Define o ambiente para impressão 	Ambiente: 1-Server e 2-Client
     //oReport:SetEdit(.T.) 
 	
 	//Verifica os parâmetros selecionados via Pergunte
@@ -33,7 +34,7 @@ User Function ZFISR005()
     TRCell():New( oSection  ,"D2_TES"      ,cAliasTMP  ,"Tes"							)
     TRCell():New( oSection  ,"F4_FINALID"  ,cAliasTMP  ,"Finalidade TES"				)
     TRCell():New( oSection  ,"B1_ORIGEM"   ,cAliasTMP  ,"Origem do Produto"			    )
-    TRCell():New( oSection  ,"B1_POSIPI"   ,cAliasTMP  ,'NCM'                      , "@!" ,TamSX3("B1_POSIPI")[1]                           )
+    TRCell():New( oSection  ,"B1_POSIPI"   ,cAliasTMP  ,"NCM"                      , "@!" ,TamSX3("B1_POSIPI")[1]                           )
     TRCell():New( oSection  ,"B1_EX_NCM"   ,cAliasTMP  ,"Ex-NCM"						)
     TRCell():New( oSection  ,"ModVei"      ,cAliasTMP  ,"Modelo Veículo"				)
     TRCell():New( oSection  ,"VRK_OPCION"  ,cAliasTMP  ,"Opcional"						)
@@ -188,9 +189,6 @@ Static Function ReportPrint(oReport)
 	Local cTpPessoa		:= ""
 	Local cTpNF			:= ""
 	Local cNumPed 		:= ""
-	Local nVlrFrete 	:= 0
-	Local nVlrSeguro	:= 0
-	Local nVlrDesp		:= 0
 	Local cMenNota		:= ""
 	Local cMenPad		:= ""
 	Local cNaturez		:= ""
@@ -199,9 +197,13 @@ Static Function ReportPrint(oReport)
 	Local cCGCLocEnt	:= ""
 	Local cNomLocEnt	:= ""
 	Local cUFLocEnt		:= "" 
+	Local nVlrFrete 	:= 0
+	Local nVlrSeguro	:= 0
+	Local nVlrDesp		:= 0
 	Local nVlIPIRegi	:= 0
 	Local nVlIPIPres	:= 0
-	
+	Local nDesconto     := 0
+    Local nDesVrIcms    := 0
     //Monta Tmp
     zTmpRadio3()
 
@@ -413,142 +415,148 @@ Static Function ReportPrint(oReport)
         zRel0003(@nVlIPIRegi, @nVlIPIPres, (cAliasTMP)->F2_ESPECIE, (cAliasTMP)->F2_DOC, (cAliasTMP)->F2_SERIE,;
                 (cAliasTMP)->D2_CLIENTE, (cAliasTMP)->D2_LOJA, (cAliasTMP)->D2_ITEM )	
 
-        oSection:Cell( "CgcCpf"      ):SetValue( cCgcCpf     ) //--Cnpj/Cpf
-        oSection:Cell( "CGCLocEnt"   ):SetValue( cCGCLocEnt  ) //--CNPJ Loc. Entr.
-        oSection:Cell( "IncEst"      ):SetValue( cIncEst     ) //--Insc.Estadual
-        oSection:Cell( "TpPessoa"    ):SetValue( cTpPessoa   ) //--Pessoa Fisica/Juridica
-        oSection:Cell( "EstCli"      ):SetValue( cEstCli     ) //--UF
-        oSection:Cell( "D2_TES"      ):SetValue( (cAliasTMP)->D2_TES ) //--Tes
+        oSection:Cell( "CgcCpf"      ):SetValue( cCgcCpf                            ) //--Cnpj/Cpf
+        oSection:Cell( "CGCLocEnt"   ):SetValue( cCGCLocEnt                         ) //--CNPJ Loc. Entr.
+        oSection:Cell( "IncEst"      ):SetValue( cIncEst                            ) //--Insc.Estadual
+        oSection:Cell( "TpPessoa"    ):SetValue( cTpPessoa                          ) //--Pessoa Fisica/Juridica
+        oSection:Cell( "EstCli"      ):SetValue( cEstCli                            ) //--UF
+        oSection:Cell( "D2_TES"      ):SetValue( (cAliasTMP)->D2_TES                ) //--Tes
         oSection:Cell( "F4_FINALID"  ):SetValue( Alltrim( (cAliasTMP)->F4_FINALID ) ) //--Finalidade TES
-        oSection:Cell( "B1_ORIGEM"   ):SetValue( AllTrim( (cAliasTMP)->B1_ORIGEM ) ) //--Origem do Produto
-        oSection:Cell( "B1_POSIPI"   ):SetValue( AllTrim( (cAliasTMP)->B1_POSIPI ) ) //--NCM
-        oSection:Cell( "B1_EX_NCM"   ):SetValue( AllTrim( (cAliasTMP)->B1_EX_NCM ) ) //--Ex-NBM
-        oSection:Cell( "ModVei"      ):SetValue( AllTrim( cModVei ) ) //--Modelo Veículo
+        oSection:Cell( "B1_ORIGEM"   ):SetValue( AllTrim( (cAliasTMP)->B1_ORIGEM  ) ) //--Origem do Produto
+        oSection:Cell( "B1_POSIPI"   ):SetValue( AllTrim( (cAliasTMP)->B1_POSIPI  ) ) //--NCM
+        oSection:Cell( "B1_EX_NCM"   ):SetValue( AllTrim( (cAliasTMP)->B1_EX_NCM  ) ) //--Ex-NBM
+        oSection:Cell( "ModVei"      ):SetValue( AllTrim( cModVei                 ) ) //--Modelo Veículo
         oSection:Cell( "VRK_OPCION"  ):SetValue( AllTrim( (cAliasTMP)->VRK_OPCION ) ) //--Opcional
-        oSection:Cell( "B1_GRUPO"    ):SetValue( AllTrim( (cAliasTMP)->B1_GRUPO ) ) //--Grupo\Linha
+        oSection:Cell( "B1_GRUPO"    ):SetValue( AllTrim( (cAliasTMP)->B1_GRUPO   ) ) //--Grupo\Linha
         oSection:Cell( "BM_DESC"     ):SetValue( AllTrim( Posicione("SBM",1,xFilial("SBM")+(cAliasTMP)->B1_GRUPO,"BM_DESC") ) ) //--Descrição do Grupo
-        //oSection:Cell( "D2_TOTAL"    ):SetValue( (cAliasTMP)->D2_TOTAL ) //--Valor Total Item
-        oSection:Cell( "D2_TOTAL"    ):SetValue( ((cAliasTMP)->D2_TOTAL )+(cAliasTMP)->D2_DESCON )  //--Valor Total Item
-        oSection:Cell( "D2_CF"       ):SetValue( (cAliasTMP)->D2_CF ) //--Cfop
+       
+        nDesconto   := (cAliasTMP)->D2_DESCON
+        nDesVrIcms  := 0
+		If  (cAliasTMP)->D2_VRDICMS > 0  .and. nDesconto >= (cAliasTMP)->D2_VRDICMS 
+			nDesVrIcms := (cAliasTMP)->D2_VRDICMS
+		EndIF
+        
+        oSection:Cell( "D2_TOTAL"    ):SetValue( iif(!lMvNFLeiZF,((cAliasTMP)->D2_TOTAL ) + nDesconto + (cAliasTMP)->D2_DESCZFR - nDesVrIcms ,;
+                                                                 ((cAliasTMP)->D2_TOTAL ) + nDesconto + (cAliasTMP)->D2_DESCZFR )-((cAliasTMP)->D2_DESCZFP+(cAliasTMP)->D2_DESCZFC+nDesVrIcms))  //--Valor Total Item
+        oSection:Cell( "D2_CF"       ):SetValue( (cAliasTMP)->D2_CF      ) //--Cfop
         oSection:Cell( "FT_VALCONT"  ):SetValue( (cAliasTMP)->FT_VALCONT ) //--Valor Contábil
-        oSection:Cell( "FT_BASEICM"  ):SetValue( (cAliasTMP)->FT_BASEICM ) //--Base ICMS
-        oSection:Cell( "FT_ALIQICM"  ):SetValue( (cAliasTMP)->FT_ALIQICM ) //--Aliq. ICMS
-        oSection:Cell( "FT_VALICM"   ):SetValue( (cAliasTMP)->FT_VALICM ) //--Valor ICMS
-        oSection:Cell( "C6_XVLCOM"   ):SetValue( (cAliasTMP)->C6_XVLCOM ) //--Comissão
+        oSection:Cell( "FT_BASEICM"  ):SetValue( iif( Alltrim((cAliasTMP)->F2_ESPECIE) <> "RPS",(cAliasTMP)->FT_BASEICM ,0 ) ) //--Base ICMS
+        oSection:Cell( "FT_ALIQICM"  ):SetValue( iif( Alltrim((cAliasTMP)->F2_ESPECIE) <> "RPS",(cAliasTMP)->FT_ALIQICM ,0 ) ) //--Aliq. ICMS
+        oSection:Cell( "FT_VALICM"   ):SetValue( iif( Alltrim((cAliasTMP)->F2_ESPECIE) <> "RPS",(cAliasTMP)->FT_VALICM  ,0 ) ) //--Valor ICMS
+        oSection:Cell( "C6_XVLCOM"   ):SetValue( (cAliasTMP)->C6_XVLCOM  ) //--Comissão
         oSection:Cell( "FT_BASEIPI"  ):SetValue( (cAliasTMP)->FT_BASEIPI ) //--Base IPI
         oSection:Cell( "FT_ALIQIPI"  ):SetValue( (cAliasTMP)->FT_ALIQIPI ) //--Aliq. IPI
-        oSection:Cell( "FT_VALIPI"   ):SetValue( (cAliasTMP)->FT_VALIPI ) //--Valor IPI
-        oSection:Cell( "VlIPIRegi"   ):SetValue( nVlIPIRegi ) //--Credito_Regional IPI
-        oSection:Cell( "VlIPIPres"   ):SetValue( nVlIPIPres ) //--Credito_Presumido IPI/Frete
+        oSection:Cell( "FT_VALIPI"   ):SetValue( (cAliasTMP)->FT_VALIPI  ) //--Valor IPI
+        oSection:Cell( "VlIPIRegi"   ):SetValue( nVlIPIRegi              ) //--Credito_Regional IPI
+        oSection:Cell( "VlIPIPres"   ):SetValue( nVlIPIPres              ) //--Credito_Presumido IPI/Frete
         oSection:Cell( "FT_BASERET"  ):SetValue( (cAliasTMP)->FT_BASERET ) //--Base Subst
         oSection:Cell( "FT_ICMSRET"  ):SetValue( (cAliasTMP)->FT_ICMSRET ) //--Valor Subst
         oSection:Cell( "FT_BASEPIS"  ):SetValue( (cAliasTMP)->FT_BASEPIS ) //--Base Pis Apuração
         oSection:Cell( "FT_ALIQPIS"  ):SetValue( (cAliasTMP)->FT_ALIQPIS ) //--Aliq. Pis Apuração
-        oSection:Cell( "FT_VALPIS"   ):SetValue( (cAliasTMP)->FT_VALPIS ) //--Valor Pis Apuração
+        oSection:Cell( "FT_VALPIS"   ):SetValue( (cAliasTMP)->FT_VALPIS  ) //--Valor Pis Apuração
         oSection:Cell( "FT_BASECOF"  ):SetValue( (cAliasTMP)->FT_BASECOF ) //--Base Cofins Apuração
         oSection:Cell( "FT_ALIQCOF"  ):SetValue( (cAliasTMP)->FT_ALIQCOF ) //--Aliq. Cofins Apuração
-        oSection:Cell( "FT_VALCOF"   ):SetValue( (cAliasTMP)->FT_VALCOF ) //--Valor Cofins Apuração
+        oSection:Cell( "FT_VALCOF"   ):SetValue( (cAliasTMP)->FT_VALCOF  ) //--Valor Cofins Apuração
         oSection:Cell( "FT_BASEPS3"  ):SetValue( (cAliasTMP)->FT_BASEPS3 ) //--Base Pis ST ZFM
         oSection:Cell( "FT_ALIQPS3"  ):SetValue( (cAliasTMP)->FT_ALIQPS3 ) //--Aliq. Pis ST ZFM
-        oSection:Cell( "FT_VALPS3"   ):SetValue( (cAliasTMP)->FT_VALPS3 ) //--Vl. Pis ST ZFM
+        oSection:Cell( "FT_VALPS3"   ):SetValue( (cAliasTMP)->FT_VALPS3  ) //--Vl. Pis ST ZFM
         oSection:Cell( "FT_BASECF3"  ):SetValue( (cAliasTMP)->FT_BASECF3 ) //--Base Cof ST ZFM
         oSection:Cell( "FT_ALIQCF3"  ):SetValue( (cAliasTMP)->FT_ALIQCF3 ) //--Aliq. Cof ST ZFM
-        oSection:Cell( "FT_VALCF3"   ):SetValue( (cAliasTMP)->FT_VALCF3 ) //--Vl. Cof ST ZFM
-        oSection:Cell( "FT_DIFAL"    ):SetValue( (cAliasTMP)->FT_DIFAL ) //--ICMS Difal
+        oSection:Cell( "FT_VALCF3"   ):SetValue( (cAliasTMP)->FT_VALCF3  ) //--Vl. Cof ST ZFM
+        oSection:Cell( "FT_DIFAL"    ):SetValue( (cAliasTMP)->FT_DIFAL   ) //--ICMS Difal
         oSection:Cell( "FT_CLASFIS"  ):SetValue( (cAliasTMP)->FT_CLASFIS ) //--CST ICMS
-        oSection:Cell( "FT_CTIPI"    ):SetValue( (cAliasTMP)->FT_CTIPI ) //--CST IPI
-        oSection:Cell( "FT_CSTPIS"   ):SetValue( (cAliasTMP)->FT_CSTPIS ) //--CST PIS
-        oSection:Cell( "FT_CSTCOF"   ):SetValue( (cAliasTMP)->FT_CSTCOF ) //--CST COFINS
-        oSection:Cell( "F4_ICM"      ):SetValue( (cAliasTMP)->F4_ICM ) //--Calcula ICMS
+        oSection:Cell( "FT_CTIPI"    ):SetValue( (cAliasTMP)->FT_CTIPI   ) //--CST IPI
+        oSection:Cell( "FT_CSTPIS"   ):SetValue( (cAliasTMP)->FT_CSTPIS  ) //--CST PIS
+        oSection:Cell( "FT_CSTCOF"   ):SetValue( (cAliasTMP)->FT_CSTCOF  ) //--CST COFINS
+        oSection:Cell( "F4_ICM"      ):SetValue( (cAliasTMP)->F4_ICM     ) //--Calcula ICMS
         oSection:Cell( "F4_CREDICM"  ):SetValue( (cAliasTMP)->F4_CREDICM ) //--Credita ICMS
-        oSection:Cell( "F4_IPI"      ):SetValue( (cAliasTMP)->F4_IPI ) //--Calcula IPI
+        oSection:Cell( "F4_IPI"      ):SetValue( (cAliasTMP)->F4_IPI     ) //--Calcula IPI
         oSection:Cell( "F4_CREDIPI"  ):SetValue( (cAliasTMP)->F4_CREDIPI ) //--Credita IPI
-        oSection:Cell( "D2_DOC"      ):SetValue( (cAliasTMP)->D2_DOC ) //--Nota Fiscal
+        oSection:Cell( "D2_DOC"      ):SetValue( (cAliasTMP)->D2_DOC     ) //--Nota Fiscal
         oSection:Cell( "NfPref"      ):SetValue( IIF( AllTrim( (cAliasTMP)->F2_ESPECIE ) == 'NFS', (cAliasTMP)->D2_DOC, "" ) ) //--Nf. Prefeitura
-        oSection:Cell( "D2_SERIE"    ):SetValue( (cAliasTMP)->D2_SERIE ) //--Série
+        oSection:Cell( "D2_SERIE"    ):SetValue( (cAliasTMP)->D2_SERIE   ) //--Série
         oSection:Cell( "F2_ESPECIE"  ):SetValue( (cAliasTMP)->F2_ESPECIE ) //--Espécie
         oSection:Cell( "ModNot"      ):SetValue( AModNot( (cAliasTMP)->F2_ESPECIE ) ) //--Modelo
         oSection:Cell( "D2_EMISSAO"  ):SetValue( IIF( Empty( SToD( (cAliasTMP)->D2_EMISSAO ) ), "", SToD( (cAliasTMP)->D2_EMISSAO ) ) ) //--Dt. de Emissão
         oSection:Cell( "D2_CLIENTE"  ):SetValue( (cAliasTMP)->D2_CLIENTE ) //--Cliente\Fornecedor
-        oSection:Cell( "D2_LOJA"     ):SetValue( (cAliasTMP)->D2_LOJA ) //--Loja
-        oSection:Cell( "CliFor"      ):SetValue( cCliFor ) //--Nome
+        oSection:Cell( "D2_LOJA"     ):SetValue( (cAliasTMP)->D2_LOJA    ) //--Loja
+        oSection:Cell( "CliFor"      ):SetValue( cCliFor                 ) //--Nome
         oSection:Cell( "C6_CHASSI"   ):SetValue( AllTrim( (cAliasTMP)->C6_CHASSI ) ) //--Chassi
-        oSection:Cell( "D2_COD"      ):SetValue( (cAliasTMP)->D2_COD ) //--Cód.Produto
+        oSection:Cell( "D2_COD"      ):SetValue( (cAliasTMP)->D2_COD     ) //--Cód.Produto
         oSection:Cell( "B1_DESC"     ):SetValue( Substr( (cAliasTMP)->B1_DESC,1,20 ) ) //--Descrição do Produto
         oSection:Cell( "B5_CEME"     ):SetValue( AllTrim( Posicione("SB5",1,xFilial("SB5")+(cAliasTMP)->D2_COD,"B5_CEME") ) ) //--Descrição Científico
         oSection:Cell( "B1_XDESCL1"  ):SetValue( AllTrim( (cAliasTMP)->B1_XDESCL1 ) ) //--Descrição Longa
-        oSection:Cell( "D2_UM"       ):SetValue( (cAliasTMP)->D2_UM ) //--Un Medida
-        oSection:Cell( "D2_QUANT"    ):SetValue( (cAliasTMP)->D2_QUANT ) //--Quant
-        oSection:Cell( "D2_PRUNIT"   ):SetValue( (cAliasTMP)->D2_PRUNIT ) //--Valor Unit. Item
+        oSection:Cell( "D2_UM"       ):SetValue( (cAliasTMP)->D2_UM      ) //--Un Medida
+        oSection:Cell( "D2_QUANT"    ):SetValue( (cAliasTMP)->D2_QUANT   ) //--Quant
+        oSection:Cell( "D2_PRUNIT"   ):SetValue( (cAliasTMP)->D2_PRUNIT  ) //--Valor Unit. Item
       //oSection:Cell( "D2_DESC"     ):SetValue( (cAliasTMP)->D2_DESC ) //--Desconto Item
         //oSection:Cell( "D2_DESCON"   ):SetValue( (cAliasTMP)->D2_DESCON ) //--Desconto Item
-        oSection:Cell( "FT_DESCONT"   ):SetValue( (cAliasTMP)->FT_DESCONT ) //--Desconto Item
-        oSection:Cell( "VlrFrete"    ):SetValue( nVlrFrete ) //--Frete
-        oSection:Cell( "VlrSeguro"   ):SetValue( nVlrSeguro ) //--Seguro
-        oSection:Cell( "VlrDesp"     ):SetValue( nVlrDesp ) //--Despesas
-        oSection:Cell( "D2_CUSTO1"   ):SetValue( (cAliasTMP)->D2_CUSTO1 ) //--Custo
-        oSection:Cell( "D2_CONTA"    ):SetValue( (cAliasTMP)->D2_CONTA ) //--Conta Contábil
+        oSection:Cell( "FT_DESCONT"   ):SetValue( (cAliasTMP)->FT_DESCONT) //--Desconto Item
+        oSection:Cell( "VlrFrete"    ):SetValue( nVlrFrete               ) //--Frete
+        oSection:Cell( "VlrSeguro"   ):SetValue( nVlrSeguro              ) //--Seguro
+        oSection:Cell( "VlrDesp"     ):SetValue( nVlrDesp                ) //--Despesas
+        oSection:Cell( "D2_CUSTO1"   ):SetValue( (cAliasTMP)->D2_CUSTO1  ) //--Custo
+        oSection:Cell( "D2_CONTA"    ):SetValue( (cAliasTMP)->D2_CONTA   ) //--Conta Contábil
         oSection:Cell( "CT1_DESC01"  ):SetValue( AllTrim( Posicione("CT1",1,xFilial("CT1")+(cAliasTMP)->D2_CONTA,"CT1_DESC01" ) ) ) //--Desc.Conta Contábil
         oSection:Cell( "D2_FILIAL"   ):SetValue( AllTrim( (cAliasTMP)->D2_FILIAL ) ) //--Empresa
-        oSection:Cell( "Situacao"    ):SetValue( cSituacao ) //--Situação
-        oSection:Cell( "TpNF"        ):SetValue( cTpNF ) //--Tipo Nota Fiscal
-        oSection:Cell( "FT_CHVNFE"   ):SetValue( (cAliasTMP)->FT_CHVNFE ) //--Chave Nota Fiscal
+        oSection:Cell( "Situacao"    ):SetValue( cSituacao               ) //--Situação
+        oSection:Cell( "TpNF"        ):SetValue( cTpNF                   ) //--Tipo Nota Fiscal
+        oSection:Cell( "FT_CHVNFE"   ):SetValue( (cAliasTMP)->FT_CHVNFE  ) //--Chave Nota Fiscal
         oSection:Cell( "D2_NFORI"    ):SetValue( AllTrim( (cAliasTMP)->D2_NFORI ) + " - " + AllTrim( (cAliasTMP)->D2_SERIORI ) ) //--Nota Fiscal Origem
-        oSection:Cell( "DescTipo"    ):SetValue( cDescTipo ) //--Tipo Cli\For
-        oSection:Cell( "TpCliFor"    ):SetValue( cTpCliFor ) //--Cli\For
-        oSection:Cell( "X5_DESCRI"   ):SetValue( AllTrim( Posicione("SX5" ,1 ,xFilial("SX5") + "12" + cEstCli,"X5_DESCRI") ) ) //--Estado
+        oSection:Cell( "DescTipo"    ):SetValue( cDescTipo               ) //--Tipo Cli\For
+        oSection:Cell( "TpCliFor"    ):SetValue( cTpCliFor               ) //--Cli\For
+        oSection:Cell( "X5_DESCRI"   ):SetValue( AllTrim( Posicione("SX5" ,1 ,xFilial("SX5") + "12" + cEstCli                                     ,"X5_DESCRI") ) ) //--Estado
         oSection:Cell( "CC2_MUN"     ):SetValue( AllTrim( Posicione("CC2" ,1 ,xFilial("CC2") + cEstCli + PadR( cCodMun ,TamSx3("CC2_CODMUN")[1] ) , "CC2_MUN" ) ) ) //--Município
         oSection:Cell( "B1_CEST"     ):SetValue( AllTrim( (cAliasTMP)->B1_CEST ) ) //--CEST
-        oSection:Cell( "DesMod"      ):SetValue( AllTrim( cDesMod ) ) //--Descr. Modelo Veículo
-        oSection:Cell( "ComVei"      ):SetValue( AllTrim( cComVei ) ) //--Combustível Veículo
+        oSection:Cell( "DesMod"      ):SetValue( AllTrim( cDesMod      ) ) //--Descr. Modelo Veículo
+        oSection:Cell( "ComVei"      ):SetValue( AllTrim( cComVei      ) ) //--Combustível Veículo
         oSection:Cell( "F4_TEXTO"    ):SetValue( AllTrim( (cAliasTMP)->F4_TEXTO ) ) //--Descrição CFOP
-        oSection:Cell( "F2_CODNFE"   ):SetValue( (cAliasTMP)->F2_CODNFE ) //--Cód.Verificação
+        oSection:Cell( "F2_CODNFE"   ):SetValue( (cAliasTMP)->F2_CODNFE  ) //--Cód.Verificação
         oSection:Cell( "FT_BASEIRR"  ):SetValue( (cAliasTMP)->FT_BASEIRR ) //--Base Irrf Retenção
         oSection:Cell( "FT_ALIQIRR"  ):SetValue( (cAliasTMP)->FT_ALIQIRR ) //--Aliq. Irrf Retenção
-        oSection:Cell( "FT_VALIRR"   ):SetValue( (cAliasTMP)->FT_VALIRR ) //--Irrf Retenção
+        oSection:Cell( "FT_VALIRR"   ):SetValue( (cAliasTMP)->FT_VALIRR  ) //--Irrf Retenção
         oSection:Cell( "FT_BASEINS"  ):SetValue( (cAliasTMP)->FT_BASEINS ) //--Base Inss
         oSection:Cell( "FT_ALIQINS"  ):SetValue( (cAliasTMP)->FT_ALIQINS ) //--Aliq. Inss
         oSection:Cell( "D2_ABATINS"  ):SetValue( (cAliasTMP)->D2_ABATINS ) //--Inss Recolhido
-        oSection:Cell( "FT_VALINS"   ):SetValue( (cAliasTMP)->FT_VALINS ) //--Valor Inss
+        oSection:Cell( "FT_VALINS"   ):SetValue( (cAliasTMP)->FT_VALINS  ) //--Valor Inss
         oSection:Cell( "D2_BASEISS"  ):SetValue( (cAliasTMP)->D2_BASEISS ) //--Base Iss
         oSection:Cell( "D2_ALIQISS"  ):SetValue( (cAliasTMP)->D2_ALIQISS ) //--Aliq. Iss
         oSection:Cell( "D2_ABATISS"  ):SetValue( (cAliasTMP)->D2_ABATISS ) //--Iss Serviços
         oSection:Cell( "D2_ABATMAT"  ):SetValue( (cAliasTMP)->D2_ABATMAT ) //--Iss Materiais
-        oSection:Cell( "D2_VALISS"   ):SetValue( (cAliasTMP)->D2_VALISS ) //--Valor Iss
+        oSection:Cell( "D2_VALISS"   ):SetValue( (cAliasTMP)->D2_VALISS  ) //--Valor Iss
         oSection:Cell( "FT_BASECSL"  ):SetValue( (cAliasTMP)->FT_BASECSL ) //--Base Csll
         oSection:Cell( "FT_ALIQCSL"  ):SetValue( IIF( (cAliasTMP)->FT_BASECSL > 0, (cAliasTMP)->FT_ALIQCSL, 0 ) ) //--Aliq. Csll
-        oSection:Cell( "FT_VALCSL"   ):SetValue( (cAliasTMP)->FT_VALCSL ) //--Valor Csll
+        oSection:Cell( "FT_VALCSL"   ):SetValue( (cAliasTMP)->FT_VALCSL  ) //--Valor Csll
         oSection:Cell( "FT_BRETPIS"  ):SetValue( (cAliasTMP)->FT_BRETPIS ) //--Base Pis Retenção
         oSection:Cell( "FT_ARETPIS"  ):SetValue( IIF( (cAliasTMP)->FT_BRETPIS > 0, (cAliasTMP)->FT_ARETPIS, 0 ) ) //--Aliq. Pis Retenção
         oSection:Cell( "FT_VRETPIS"  ):SetValue( (cAliasTMP)->FT_VRETPIS ) //--Valor Pis Retenção
         oSection:Cell( "FT_BRETCOF"  ):SetValue( (cAliasTMP)->FT_BRETCOF ) //--Base Cofins Retenção
         oSection:Cell( "FT_ARETCOF"  ):SetValue( IIF( (cAliasTMP)->FT_BRETCOF > 0, (cAliasTMP)->FT_ARETCOF, 0 ) ) //--Aliq. Cofins Retenção
-        oSection:Cell( "FT_VRETCOF"   ):SetValue( (cAliasTMP)->FT_VRETCOF ) //--Valor Cofins Retenção
-        oSection:Cell( "LogInc"      ):SetValue( cLogInc ) //--Log. de Inclusão
-        oSection:Cell( "LogAlt"      ):SetValue( cLogAlt ) //--Log. de Alteração
-        oSection:Cell( "DtLogAlt"    ):SetValue( cDtLogAlt ) //--Dt. Log. de Alteração
+        oSection:Cell( "FT_VRETCOF"  ):SetValue( (cAliasTMP)->FT_VRETCOF ) //--Valor Cofins Retenção
+        oSection:Cell( "LogInc"      ):SetValue( cLogInc                 ) //--Log. de Inclusão
+        oSection:Cell( "LogAlt"      ):SetValue( cLogAlt                 ) //--Log. de Alteração
+        oSection:Cell( "DtLogAlt"    ):SetValue( cDtLogAlt               ) //--Dt. Log. de Alteração
         oSection:Cell( "VV3_TIPVEN"  ):SetValue( AllTrim( (cAliasTMP)->VV3_TIPVEN ) ) //--Tipo Venda
         oSection:Cell( "VV3_DESCRI"  ):SetValue( AllTrim( (cAliasTMP)->VV3_DESCRI ) ) //--Descr. Tipo Venda
-        oSection:Cell( "NumPed"      ):SetValue( cNumPed ) //--Num. Pedido
-        oSection:Cell( "Naturez"     ):SetValue( cNaturez ) //--Natureza Financeira
+        oSection:Cell( "NumPed"      ):SetValue( cNumPed                 ) //--Num. Pedido
+        oSection:Cell( "Naturez"     ):SetValue( cNaturez                ) //--Natureza Financeira
         oSection:Cell( "C6_TNATREC"  ):SetValue( AllTrim( (cAliasTMP)->C6_TNATREC ) ) //--Tab. Nat. Receita
         oSection:Cell( "D2_ITEMCC"   ):SetValue( AllTrim( (cAliasTMP)->D2_ITEMCC ) ) //--Item Contábil
         oSection:Cell( "F3_ISENICM"  ):SetValue( (cAliasTMP)->F3_ISENICM ) //--ICMS Isento
         oSection:Cell( "F3_OUTRICM"  ):SetValue( (cAliasTMP)->F3_OUTRICM ) //--ICMS Outros
         oSection:Cell( "F3_ISENIPI"  ):SetValue( (cAliasTMP)->F3_ISENIPI ) //--IPI Isento
         oSection:Cell( "F3_OUTRIPI"  ):SetValue( (cAliasTMP)->F3_OUTRIPI ) //--IPI Outros
-        oSection:Cell( "Transp"      ):SetValue( cTransp ) //--Cód. Transportadora
+        oSection:Cell( "Transp"      ):SetValue( cTransp                 ) //--Cód. Transportadora
         oSection:Cell( "VRJ_CLIRET"  ):SetValue( (cAliasTMP)->VRJ_CLIRET ) //--Cat. Local de Entrega
-        oSection:Cell( "NomLocEnt"   ):SetValue( cNomLocEnt ) //--Nome Loc. Entr.
-        oSection:Cell( "UFLocEnt"    ):SetValue( cUFLocEnt ) //--UF Loc. Entr.
+        oSection:Cell( "NomLocEnt"   ):SetValue( cNomLocEnt              ) //--Nome Loc. Entr.
+        oSection:Cell( "UFLocEnt"    ):SetValue( cUFLocEnt               ) //--UF Loc. Entr.
         oSection:Cell( "F2_MENNOTA"  ):SetValue( (cAliasTMP)->F2_MENNOTA ) //--Msgn Nota Fiscal   
-        oSection:Cell( "MenNota"     ):SetValue( cMenNota ) //--Mens.p/Nota
-        oSection:Cell( "MenPad"      ):SetValue( cMenPad ) //--Mens. Padrão
-        oSection:Cell( "MensNFS"     ):SetValue( cMensNFS ) //--Mensagem NFS	
+        oSection:Cell( "MenNota"     ):SetValue( cMenNota                ) //--Mens.p/Nota
+        oSection:Cell( "MenPad"      ):SetValue( cMenPad                 ) //--Mens. Padrão
+        oSection:Cell( "MensNFS"     ):SetValue( cMensNFS                ) //--Mensagem NFS	
         oSection:Cell( "VlrTrib"     ):SetValue( (cAliasTMP)->( F2_TOTFED + F2_TOTEST ) ) //--Vlr. Aprox. dos Tributos	
         oSection:Cell( "F4_DUPLIC"   ):SetValue( Alltrim( (cAliasTMP)->F4_DUPLIC ) ) //--Gera Duplicata   
         //oSection:Cell( "WRK_CHASSI"  ):SetValue( Alltrim( (cAliasTMP)->VRK_CHASSI ) ) //--Gera Duplicata   
-
 
         oSection:PrintLine()
 
@@ -564,149 +572,149 @@ Static Function zTmpRadio3()
     Local cQuery    := ""
     
 	If Select( cAliasTMP ) > 0
-		(cAliasTMP)->(DbCloseArea()) 
+		(cAliasTMP)->(DbCloseArea())
 	EndIf
 
-    cQuery += " SELECT D2_FILIAL, D2_COD, D2_DOC,D2_SERIE, D2_TES, D2_CF,D2_CLIENTE,D2_LOJA,D2_EMISSAO, D2_ITEMPV, "		+ CRLF
-	cQuery += " F4_FINALID, F4_TEXTO, FT_CTIPI, FT_CSTPIS, FT_CSTCOF, F4_ICM, F4_IPI, F4_CREDICM, F4_CREDIPI, F4_DUPLIC, "	+ CRLF
-	cQuery += " B1_DESC, B1_XDESCL1, B1_GRUPO, B1_POSIPI, B1_CEST, B1_ORIGEM, B1_EX_NCM,  B1_EX_NBM, D2_ITEM, "							+ CRLF
-	cQuery += " F2_ESPECIE,F2_CODNFE,F2_MENNOTA,F2_USERLGI,F2_USERLGA,F2_TIPO, FT_CHVNFE,F2_DOC, F2_SERIE, F2_FIMP,  " 		+ CRLF
-	cQuery += " FT_VALCONT, FT_DESCONT, F2_FORMUL, D2_CONTA, D2_NFORI, D2_SERIORI, D2_PRUNIT,D2_TOTAL, "					+ CRLF
-	cQuery += " D2_DESC, D2_DESCON, FT_CLASFIS, D2_DESCZFP, D2_DESCZFC, D2_TIPO, "											+ CRLF
-	cQuery += " FT_BASEICM, FT_ALIQICM, FT_VALICM, C6_CHASSI, "																+ CRLF
-	cQuery += " FT_BASEIPI, FT_ALIQIPI, FT_VALIPI, FT_BRETPIS, FT_ARETPIS, FT_VRETPIS, FT_BRETCOF, FT_ARETCOF, FT_VRETCOF, "+ CRLF
-	cQuery += " FT_BASERET, FT_ICMSRET, FT_DIFAL, "																			+ CRLF
-	cQuery += " D2_BASIMP6,D2_ALQIMP6,D2_VALIMP6,   " 																		+ CRLF
-	cQuery += " D2_BASIMP5,D2_ALQIMP5,D2_VALIMP5, " 											                            + CRLF
-	cQuery += " FT_BASEPIS,FT_ALIQPIS,FT_VALPIS, F2_TOTFED, F2_TOTEST, "													+ CRLF
-	cQuery += " FT_BASECOF,FT_ALIQCOF,FT_VALCOF, FT_BASECF3, FT_ALIQCF3, FT_VALCF3, FT_BASEPS3, FT_ALIQPS3, FT_VALPS3, "	+ CRLF
-	cQuery += " FT_BASEIRR,FT_ALIQIRR,FT_VALIRR, F3_OUTRIPI, F3_ISENIPI, F3_OUTRICM, F3_ISENICM,  "							+ CRLF
-	cQuery += " FT_BASEINS,FT_ALIQINS,D2_ABATINS,FT_VALINS, D2_UM, D2_QUANT, "												+ CRLF
-	cQuery += " D2_BASEISS,D2_ALIQISS,D2_ABATISS,D2_ABATMAT,D2_VALISS, D2_ITEMCC, "											+ CRLF
-	cQuery += " FT_BASECSL,FT_ALIQCSL,FT_VALCSL, D2_CUSTO1, VRK_CHASSI, VRJ_CODCLI, VRJ_LOJA, C6_XVLCOM, "					+ CRLF
-	cQuery += " C6_TNATREC, C6_NFORI, C6_FILIAL, C6_NUM, VV3_TIPVEN, VV3_DESCRI, VRJ_CLIRET, VRK_OPCION "		            + CRLF
-	cQuery += " FROM   " + RetSQLName("SD2") + " SD2   " 																	+ CRLF
-	
-	cQuery += "	INNER JOIN " + RetSQLName("SF2") + " SF2 "																    + CRLF
-	cQuery += "		ON SF2.F2_FILIAL = '" + FWxFilial('SF2') + "' "													        + CRLF
-	cQuery += "		AND SD2.D2_DOC = SF2.F2_DOC   " 																	    + CRLF
-	cQuery += "		AND SD2.D2_SERIE = SF2.F2_SERIE   " 																    + CRLF
-	cQuery += "		AND SD2.D2_CLIENTE = SF2.F2_CLIENTE   " 															    + CRLF
-	cQuery += "		AND SD2.D2_LOJA = SF2.F2_LOJA   " 																	    + CRLF
-	cQuery += "		AND SD2.D2_EMISSAO = SF2.F2_EMISSAO   " 															    + CRLF
-	cQuery += "		AND SF2.F2_ESPECIE BETWEEN '" + MV_PAR03 + "' AND '" + MV_PAR04 + "' " 								    + CRLF
-	cQuery += "		AND SF2.D_E_L_E_T_ = ' '   "	 																	    + CRLF
+    cQuery += CRLF + " SELECT D2_FILIAL , D2_COD    , D2_DOC    , D2_SERIE  , D2_TES    , D2_CF    , D2_CLIENTE, D2_LOJA    , D2_EMISSAO , D2_ITEMPV, "
+	cQuery += CRLF + "        F4_FINALID, F4_TEXTO  , FT_CTIPI  , FT_CSTPIS , FT_CSTCOF , F4_ICM   , F4_IPI    , F4_CREDICM , F4_CREDIPI , F4_DUPLIC, "
+	cQuery += CRLF + "        B1_DESC   , B1_XDESCL1, B1_GRUPO  , B1_POSIPI , B1_CEST   , B1_ORIGEM, B1_EX_NCM , B1_EX_NBM  , D2_ITEM    , "
+	cQuery += CRLF + "        F2_ESPECIE, F2_CODNFE , F2_MENNOTA, F2_USERLGI,F2_USERLGA , F2_TIPO  , FT_CHVNFE , F2_DOC     , F2_SERIE   , F2_FIMP,  "
+	cQuery += CRLF + "        FT_VALCONT, FT_DESCONT, F2_FORMUL , D2_CONTA  , D2_NFORI  , D2_SERIORI, D2_PRUNIT, D2_TOTAL  , "
+	cQuery += CRLF + "        D2_DESC   , D2_DESCON , FT_CLASFIS, D2_DESCZFP, D2_DESCZFC, D2_TIPO, "
+	cQuery += CRLF + "        FT_BASEICM, FT_ALIQICM, FT_VALICM , C6_CHASSI , "
+	cQuery += CRLF + "        FT_BASEIPI, FT_ALIQIPI, FT_VALIPI , FT_BRETPIS, FT_ARETPIS, FT_VRETPIS, FT_BRETCOF, FT_ARETCOF, FT_VRETCOF, "
+	cQuery += CRLF + "        FT_BASERET, FT_ICMSRET, FT_DIFAL  , "
+	cQuery += CRLF + "        D2_BASIMP6, D2_ALQIMP6, D2_VALIMP6, "
+	cQuery += CRLF + "        D2_BASIMP5, D2_ALQIMP5, D2_VALIMP5, "
+	cQuery += CRLF + "        FT_BASEPIS, FT_ALIQPIS, FT_VALPIS , F2_TOTFED , F2_TOTEST, "
+	cQuery += CRLF + "        FT_BASECOF, FT_ALIQCOF, FT_VALCOF , FT_BASECF3, FT_ALIQCF3, FT_VALCF3 , FT_BASEPS3, FT_ALIQPS3, FT_VALPS3, "
+	cQuery += CRLF + "        FT_BASEIRR, FT_ALIQIRR, FT_VALIRR , F3_OUTRIPI, F3_ISENIPI, F3_OUTRICM, F3_ISENICM, "
+	cQuery += CRLF + "        FT_BASEINS, FT_ALIQINS, D2_ABATINS, FT_VALINS , D2_UM     , D2_QUANT  , "
+	cQuery += CRLF + "        D2_BASEISS, D2_ALIQISS, D2_ABATISS, D2_ABATMAT, D2_VALISS , D2_ITEMCC , "
+	cQuery += CRLF + "        FT_BASECSL, FT_ALIQCSL, FT_VALCSL , D2_CUSTO1 , VRK_CHASSI, VRJ_CODCLI, VRJ_LOJA  , C6_XVLCOM, "
+	cQuery += CRLF + "        C6_TNATREC, C6_NFORI, C6_FILIAL   , C6_NUM    , VV3_TIPVEN, VV3_DESCRI, VRJ_CLIRET, VRK_OPCION, D2_DESCZFR, D2_VRDICMS  "
+	cQuery += CRLF + " FROM   " + RetSQLName("SD2") + " SD2   "
+
+	cQuery += CRLF + "	INNER JOIN " + RetSQLName("SF2") + " SF2 "
+	cQuery += CRLF + "		ON SF2.F2_FILIAL   = '" + FWxFilial('SF2') + "' "
+	cQuery += CRLF + "		AND SD2.D2_DOC     = SF2.F2_DOC "
+	cQuery += CRLF + "		AND SD2.D2_SERIE   = SF2.F2_SERIE "
+	cQuery += CRLF + "		AND SD2.D2_CLIENTE = SF2.F2_CLIENTE "
+	cQuery += CRLF + "		AND SD2.D2_LOJA    = SF2.F2_LOJA  "
+	cQuery += CRLF + "		AND SD2.D2_EMISSAO = SF2.F2_EMISSAO "
+	cQuery += CRLF + "		AND SF2.F2_ESPECIE BETWEEN '" + MV_PAR03 + "' AND '" + MV_PAR04 + "' "
+	cQuery += CRLF + "		AND SF2.D_E_L_E_T_ = ' ' "
 
 	If !Empty( MV_PAR17 )
-		cQuery += " 	AND SF2.F2_EST = '" + MV_PAR17 + "' " 															    + CRLF
+		cQuery += CRLF + " 	AND SF2.F2_EST = '" + MV_PAR17 + "' "
 	EndIf
 	
-	cQuery += " INNER JOIN " + RetSQLName("SB1") + " SB1 " 												 				    + CRLF
-	cQuery += "		ON SB1.B1_FILIAL = '" + FWxFilial('SB1') + "' "													        + CRLF
-	cQuery += "		AND SB1.B1_COD = SD2.D2_COD   "	 																	    + CRLF
-	cQuery += "		AND SB1.D_E_L_E_T_ = ' ' " 																			    + CRLF
+	cQuery += CRLF + " INNER JOIN " + RetSQLName("SB1") + " SB1 "
+	cQuery += CRLF + "		ON  SB1.B1_FILIAL  = '" + FWxFilial('SB1') + "' "
+	cQuery += CRLF + "		AND SB1.B1_COD     = SD2.D2_COD "
+	cQuery += CRLF + "		AND SB1.D_E_L_E_T_ = ' ' "
 
 	If !Empty( MV_PAR18 )
-		cQuery += " 	AND SB1.B1_GRUPO = '" + MV_PAR18 + "' "															    + CRLF
+		cQuery += CRLF + " 	AND SB1.B1_GRUPO = '" + MV_PAR18 + "' "
 	EndIf
 
 	If !Empty( MV_PAR19 )
-		cQuery += " 	AND SB1.B1_POSIPI = '" + MV_PAR19 + "' "														    + CRLF
+		cQuery += CRLF + " 	AND SB1.B1_POSIPI = '" + MV_PAR19 + "' "
 	EndIf
 
-	cQuery += " INNER JOIN " + RetSQLName("SF4") + " SF4 "																    + CRLF
-	cQuery += "		ON SF4.F4_FILIAL = '" + FWxFilial('SF4') + "'  "												        + CRLF
-	cQuery += "		AND SF4.F4_CODIGO = SD2.D2_TES  "	 																    + CRLF
-	cQuery += "     AND SF4.D_E_L_E_T_ = ' '   " 																		    + CRLF
+	cQuery += CRLF + " INNER JOIN " + RetSQLName("SF4") + " SF4 "
+	cQuery += CRLF + "		ON  SF4.F4_FILIAL  = '" + FWxFilial('SF4') + "' "
+	cQuery += CRLF + "		AND SF4.F4_CODIGO  = SD2.D2_TES "
+	cQuery += CRLF + "      AND SF4.D_E_L_E_T_ = ' '  "
 	
-	cQuery += " LEFT JOIN " + RetSQLName("SC6") + " SC6 "																    + CRLF
-	cQuery += "		ON SC6.C6_FILIAL = '" + FWxFilial('SC6') + "' "													        + CRLF
-	cQuery += "		AND SC6.C6_NUM = SD2.D2_PEDIDO  "																	    + CRLF
-	cQuery += "		AND SC6.C6_ITEM = SD2.D2_ITEMPV  "		 															    + CRLF
-	cQuery += "		AND SC6.C6_PRODUTO = SD2.D2_COD "		 															    + CRLF
-	cQuery += "     AND SC6.D_E_L_E_T_ = ' '   " 																		    + CRLF
+	cQuery += CRLF + " LEFT JOIN " + RetSQLName("SC6") + " SC6 "
+	cQuery += CRLF + "		ON  SC6.C6_FILIAL  = '" + FWxFilial('SC6') + "' "
+	cQuery += CRLF + "		AND SC6.C6_NUM     = SD2.D2_PEDIDO  "
+	cQuery += CRLF + "		AND SC6.C6_ITEM    = SD2.D2_ITEMPV  "
+	cQuery += CRLF + "		AND SC6.C6_PRODUTO = SD2.D2_COD "
+	cQuery += CRLF + "      AND SC6.D_E_L_E_T_ = ' '   "
 	
-	cQuery += " LEFT JOIN " + RetSQLName("VV0") + " VV0 "																    + CRLF
-	cQuery += "		ON VV0.VV0_FILIAL = '" + FWxFilial('VV0') + "' "												        + CRLF
-	cQuery += "		AND VV0.VV0_NUMNFI = SF2.F2_DOC  "	 																    + CRLF
-	cQuery += "		AND VV0.VV0_SERNFI = SF2.F2_SERIE  "																    + CRLF
-	cQuery += "     AND VV0.D_E_L_E_T_ = ' '   " 																		    + CRLF
+	cQuery += CRLF + " LEFT JOIN " + RetSQLName("VV0") + " VV0 "
+	cQuery += CRLF + "		ON  VV0.VV0_FILIAL = '" + FWxFilial('VV0') + "' "
+	cQuery += CRLF + "		AND VV0.VV0_NUMNFI = SF2.F2_DOC  "
+	cQuery += CRLF + "		AND VV0.VV0_SERNFI = SF2.F2_SERIE  "
+	cQuery += CRLF + "      AND VV0.D_E_L_E_T_ = ' ' "
 	
-	cQuery += " LEFT JOIN " + RetSQLName("VV3") + " VV3 "																    + CRLF
-	cQuery += "		ON VV3.VV3_FILIAL = '" + FWxFilial('VV3') + "' " 												        + CRLF
-	cQuery += " 	AND VV3.VV3_TIPVEN = VV0.VV0_TIPVEN  "			 													    + CRLF
-	cQuery += "     AND VV3.D_E_L_E_T_ = ' '   " 																		    + CRLF
+	cQuery += CRLF + " LEFT JOIN " + RetSQLName("VV3") + " VV3 "
+	cQuery += CRLF + "		ON  VV3.VV3_FILIAL = '" + FWxFilial('VV3') + "' "
+	cQuery += CRLF + " 	    AND VV3.VV3_TIPVEN = VV0.VV0_TIPVEN  "
+	cQuery += CRLF + "      AND VV3.D_E_L_E_T_ = ' '   "
 
-	cQuery += " LEFT JOIN " + RetSQLName("VRK") + " VRK "																    + CRLF
-	cQuery += " 	ON VRK.VRK_FILIAL = '" + FWxFilial('VRK') + "' "  												        + CRLF
-	cQuery += " 	AND VRK.VRK_NUMTRA = VV0.VV0_NUMTRA  "			 													    + CRLF
-	cQuery += "     AND VRK.D_E_L_E_T_ = ' '   " 																		    + CRLF
+	cQuery += CRLF + " LEFT JOIN " + RetSQLName("VRK") + " VRK "
+	cQuery += CRLF + " 	    ON  VRK.VRK_FILIAL = '" + FWxFilial('VRK') + "' "
+	cQuery += CRLF + " 	    AND VRK.VRK_NUMTRA = VV0.VV0_NUMTRA  "
+	cQuery += CRLF + "      AND VRK.D_E_L_E_T_ = ' '   "
 
-	cQuery += " LEFT JOIN " + RetSQLName("VRJ") + " VRJ "																    + CRLF
-	cQuery += " 	ON VRJ.VRJ_FILIAL = '" + FWxFilial('VRJ') + "' "  												        + CRLF
-	cQuery += " 	AND VRJ.VRJ_PEDIDO = VRK.VRK_PEDIDO  "			 													    + CRLF
-	cQuery += "     AND VRJ.D_E_L_E_T_ = ' '   " 																		    + CRLF
+	cQuery += CRLF + " LEFT JOIN " + RetSQLName("VRJ") + " VRJ "
+	cQuery += CRLF + " 	    ON  VRJ.VRJ_FILIAL = '" + FWxFilial('VRJ') + "' "
+	cQuery += CRLF + " 	    AND VRJ.VRJ_PEDIDO = VRK.VRK_PEDIDO  "
+	cQuery += CRLF + "      AND VRJ.D_E_L_E_T_ = ' '   "
 
-	cQuery += " INNER JOIN " + RetSQLName("SFT") + " SFT " 																    + CRLF
-	cQuery += "		ON SFT.FT_FILIAL = '" + FWxFilial('SFT') + "' "													        + CRLF
-	cQuery += "		AND SFT.FT_TIPOMOV = 'S' "																			    + CRLF
-	cQuery += "		AND SFT.FT_SERIE = SD2.D2_SERIE "																	    + CRLF
-	cQuery += " 	AND SFT.FT_NFISCAL = SD2.D2_DOC "																	    + CRLF
-	cQuery += "		AND SFT.FT_CLIEFOR = SD2.D2_CLIENTE " 																    + CRLF
-	cQuery += "		AND SFT.FT_LOJA = SD2.D2_LOJA " 																	    + CRLF
-	cQuery += "		AND SFT.FT_ITEM = SD2.D2_ITEM " 																	    + CRLF
-	cQuery += "		AND SFT.FT_PRODUTO = SD2.D2_COD " 																	    + CRLF	
-	cQuery += "		AND SFT.D_E_L_E_T_ = ' ' "																			    + CRLF
+	cQuery += CRLF + " INNER JOIN " + RetSQLName("SFT") + " SFT "
+	cQuery += CRLF + "		ON  SFT.FT_FILIAL  = '" + FWxFilial('SFT') + "' "
+	cQuery += CRLF + "		AND SFT.FT_TIPOMOV = 'S' "
+	cQuery += CRLF + "		AND SFT.FT_SERIE   = SD2.D2_SERIE "
+	cQuery += CRLF + " 	    AND SFT.FT_NFISCAL = SD2.D2_DOC "
+	cQuery += CRLF + "		AND SFT.FT_CLIEFOR = SD2.D2_CLIENTE "
+	cQuery += CRLF + "		AND SFT.FT_LOJA    = SD2.D2_LOJA "
+	cQuery += CRLF + "		AND SFT.FT_ITEM    = SD2.D2_ITEM "
+	cQuery += CRLF + "		AND SFT.FT_PRODUTO = SD2.D2_COD "
+	cQuery += CRLF + "		AND SFT.D_E_L_E_T_ = ' ' "
 
-	cQuery += " INNER JOIN " + RetSQLName("SF3") + " SF3 " 																    + CRLF
-	cQuery += "		ON SF3.F3_FILIAL = '" + FWxFilial('SF3') + "' "	 												        + CRLF
-	cQuery += "		AND SF3.F3_SERIE = SFT.FT_SERIE "																	    + CRLF
-	cQuery += "		AND SF3.F3_NFISCAL = SFT.FT_NFISCAL "																    + CRLF
-	cQuery += " 	AND SF3.F3_CLIEFOR = SFT.FT_CLIEFOR "																    + CRLF
-	cQuery += "		AND SF3.F3_LOJA = SFT.FT_LOJA " 																	    + CRLF
-	cQuery += "		AND SF3.F3_IDENTFT = SFT.FT_IDENTF3 " 																    + CRLF
-	cQuery += "		AND SF3.D_E_L_E_T_ = ' ' "																			    + CRLF
+	cQuery += CRLF + " INNER JOIN " + RetSQLName("SF3") + " SF3 "
+	cQuery += CRLF + "		ON SF3.F3_FILIAL   = '" + FWxFilial('SF3') + "' "
+	cQuery += CRLF + "		AND SF3.F3_SERIE   = SFT.FT_SERIE "
+	cQuery += CRLF + "		AND SF3.F3_NFISCAL = SFT.FT_NFISCAL "
+	cQuery += CRLF + " 	    AND SF3.F3_CLIEFOR = SFT.FT_CLIEFOR "
+	cQuery += CRLF + "		AND SF3.F3_LOJA    = SFT.FT_LOJA "
+	cQuery += CRLF + "		AND SF3.F3_IDENTFT = SFT.FT_IDENTF3 "
+	cQuery += CRLF + "		AND SF3.D_E_L_E_T_ = ' ' "
 
-	cQuery += " WHERE  SD2.D2_FILIAL BETWEEN '" + MV_PAR01 + "' AND '" + MV_PAR02 + "' "								    + CRLF
-	cQuery += " 	AND SD2.D2_DOC BETWEEN '" + MV_PAR05 + "' AND '" + MV_PAR06 + "' " 									    + CRLF
-	cQuery += " 	AND SD2.D2_SERIE BETWEEN '" + MV_PAR07 + "' AND '" + MV_PAR08 + "' " 								    + CRLF
-	cQuery += " 	AND SD2.D2_CLIENTE BETWEEN '" + MV_PAR09 + "' AND '" + MV_PAR10 + "' " 								    + CRLF
-	cQuery += " 	AND SD2.D2_EMISSAO BETWEEN '" + DToS(MV_PAR11) + "' AND '" + DToS(MV_PAR12) + "' " 					    + CRLF
-	cQuery += " 	AND SD2.D2_COD BETWEEN '" + MV_PAR13 + "' AND '" + MV_PAR14 + "' " 									    + CRLF
-	cQuery += " 	AND SD2.D_E_L_E_T_ = ' ' " 																			    + CRLF
+	cQuery += CRLF + " WHERE    SD2.D2_FILIAL  BETWEEN '" + MV_PAR01 + "' AND '" + MV_PAR02 + "' "
+	cQuery += CRLF + " 	    AND SD2.D2_DOC     BETWEEN '" + MV_PAR05 + "' AND '" + MV_PAR06 + "' "
+	cQuery += CRLF + " 	    AND SD2.D2_SERIE   BETWEEN '" + MV_PAR07 + "' AND '" + MV_PAR08 + "' "
+	cQuery += CRLF + " 	    AND SD2.D2_CLIENTE BETWEEN '" + MV_PAR09 + "' AND '" + MV_PAR10 + "' "
+	cQuery += CRLF + " 	    AND SD2.D2_EMISSAO BETWEEN '" + DToS(MV_PAR11) + "' AND '" + DToS(MV_PAR12) + "' "
+	cQuery += CRLF + " 	    AND SD2.D2_COD     BETWEEN '" + MV_PAR13 + "' AND '" + MV_PAR14 + "' "
+	cQuery += CRLF + " 	    AND SD2.D_E_L_E_T_ = ' ' "
 
 	If !Empty( MV_PAR15 )
-		cQuery += " 	AND SD2.D2_TES = '" + MV_PAR15 + "' " 															    + CRLF
+		cQuery += CRLF + " 	AND SD2.D2_TES = '" + MV_PAR15 + "' "
 	EndIf
 
 	If !Empty( MV_PAR16 )
-		cQuery += " 	AND SD2.D2_CF = '" + MV_PAR16 + "' " 															    + CRLF
+		cQuery += CRLF + " 	AND SD2.D2_CF = '" + MV_PAR16 + "' "
 	EndIf  
 
     If !Empty( MV_PAR20 ) .OR. !Empty( MV_PAR21)
-	   cQuery += " 	AND SC6.C6_CHASSI  BETWEEN '" + MV_PAR20 + "' AND '" + MV_PAR21 + "' " 															    + CRLF
+	   cQuery += CRLF + " 	AND SC6.C6_CHASSI  BETWEEN '" + MV_PAR20 + "' AND '" + MV_PAR21 + "' "
     Endif
 
-	cQuery += " GROUP BY D2_FILIAL, D2_COD, D2_DOC,D2_SERIE, D2_TES, D2_CF,D2_CLIENTE,D2_LOJA,D2_EMISSAO, D2_ITEMPV, "		+ CRLF
-	cQuery += " F4_FINALID, F4_TEXTO, FT_CTIPI, FT_CSTPIS, FT_CSTCOF, F4_ICM, F4_IPI, F4_CREDICM, F4_CREDIPI, F4_DUPLIC, "	+ CRLF
-	cQuery += " B1_DESC, B1_XDESCL1, B1_GRUPO, B1_POSIPI, B1_CEST, B1_ORIGEM, B1_EX_NCM, B1_EX_NBM, D2_ITEM, "							+ CRLF
-	cQuery += " F2_ESPECIE,F2_CODNFE,F2_MENNOTA,F2_USERLGI,F2_USERLGA,F2_TIPO, FT_CHVNFE,F2_DOC, F2_SERIE, F2_FIMP,  " 		+ CRLF
-	cQuery += " FT_VALCONT, FT_DESCONT , F2_FORMUL, D2_CONTA, D2_NFORI, D2_SERIORI, D2_PRUNIT,D2_TOTAL, "					+ CRLF
-	cQuery += " D2_DESC, D2_DESCON, FT_CLASFIS, D2_DESCZFP, D2_DESCZFC, D2_TIPO, "											+ CRLF
-	cQuery += " FT_BASEICM, FT_ALIQICM, FT_VALICM, C6_CHASSI, "																+ CRLF
-	cQuery += " FT_BASEIPI, FT_ALIQIPI, FT_VALIPI, FT_BRETPIS, FT_ARETPIS, FT_VRETPIS, FT_BRETCOF, FT_ARETCOF, FT_VRETCOF, "+ CRLF
-	cQuery += " FT_BASERET, FT_ICMSRET, FT_DIFAL, "																			+ CRLF
-	cQuery += " D2_BASIMP6,D2_ALQIMP6,D2_VALIMP6,   " 																		+ CRLF
-	cQuery += " D2_BASIMP5,D2_ALQIMP5,D2_VALIMP5,   " 																		+ CRLF
-	cQuery += " FT_BASEPIS,FT_ALIQPIS,FT_VALPIS, F2_TOTFED, F2_TOTEST, " 													+ CRLF
-	cQuery += " FT_BASECOF,FT_ALIQCOF,FT_VALCOF, FT_BASECF3, FT_ALIQCF3, FT_VALCF3, FT_BASEPS3, FT_ALIQPS3, FT_VALPS3, "	+ CRLF
-	cQuery += " FT_BASEIRR,FT_ALIQIRR,FT_VALIRR, F3_OUTRIPI, F3_ISENIPI, F3_OUTRICM, F3_ISENICM,  "							+ CRLF
-	cQuery += " FT_BASEINS,FT_ALIQINS,D2_ABATINS,FT_VALINS, D2_UM, D2_QUANT, "												+ CRLF
-	cQuery += " D2_BASEISS,D2_ALIQISS,D2_ABATISS,D2_ABATMAT,D2_VALISS, D2_ITEMCC, "											+ CRLF
-	cQuery += " FT_BASECSL,FT_ALIQCSL,FT_VALCSL, D2_CUSTO1, VRK_CHASSI, VRJ_CODCLI, VRJ_LOJA, C6_XVLCOM,  "					+ CRLF
-	cQuery += " C6_TNATREC, C6_NFORI, C6_FILIAL, C6_NUM, VV3_TIPVEN, VV3_DESCRI, VRJ_CLIRET, VRK_OPCION, F2_VALBRUT "		+ CRLF
+	cQuery += CRLF + " GROUP BY D2_FILIAL , D2_COD    , D2_DOC    , D2_SERIE  , D2_TES    , D2_CF    , D2_CLIENTE, D2_LOJA   , D2_EMISSAO, D2_ITEMPV, "
+	cQuery += CRLF + "          F4_FINALID, F4_TEXTO  , FT_CTIPI  , FT_CSTPIS , FT_CSTCOF , F4_ICM   , F4_IPI    , F4_CREDICM, F4_CREDIPI, F4_DUPLIC, "
+	cQuery += CRLF + "          B1_DESC   , B1_XDESCL1, B1_GRUPO  , B1_POSIPI , B1_CEST   , B1_ORIGEM, B1_EX_NCM , B1_EX_NBM , D2_ITEM   , "
+	cQuery += CRLF + "          F2_ESPECIE, F2_CODNFE , F2_MENNOTA, F2_USERLGI, F2_USERLGA, F2_TIPO  , FT_CHVNFE , F2_DOC    , F2_SERIE  , F2_FIMP,  "
+	cQuery += CRLF + "          FT_VALCONT, FT_DESCONT, F2_FORMUL , D2_CONTA  , D2_NFORI  , D2_SERIORI, D2_PRUNIT, D2_TOTAL  , "
+	cQuery += CRLF + "          D2_DESC   , D2_DESCON , FT_CLASFIS, D2_DESCZFP, D2_DESCZFC, D2_TIPO   ,"
+	cQuery += CRLF + "          FT_BASEICM, FT_ALIQICM, FT_VALICM , C6_CHASSI ,"
+	cQuery += CRLF + "          FT_BASEIPI, FT_ALIQIPI, FT_VALIPI , FT_BRETPIS, FT_ARETPIS, FT_VRETPIS, FT_BRETCOF, FT_ARETCOF, FT_VRETCOF, "
+	cQuery += CRLF + "          FT_BASERET, FT_ICMSRET, FT_DIFAL  , "
+ 	cQuery += CRLF + "          D2_BASIMP6, D2_ALQIMP6, D2_VALIMP6, " 
+ 	cQuery += CRLF + "          D2_BASIMP5, D2_ALQIMP5, D2_VALIMP5, "
+ 	cQuery += CRLF + "          FT_BASEPIS, FT_ALIQPIS, FT_VALPIS , F2_TOTFED , F2_TOTEST , "
+	cQuery += CRLF + "          FT_BASECOF, FT_ALIQCOF, FT_VALCOF , FT_BASECF3, FT_ALIQCF3, FT_VALCF3 , FT_BASEPS3, FT_ALIQPS3, FT_VALPS3, "
+	cQuery += CRLF + "          FT_BASEIRR, FT_ALIQIRR, FT_VALIRR , F3_OUTRIPI, F3_ISENIPI, F3_OUTRICM, F3_ISENICM, "
+	cQuery += CRLF + "          FT_BASEINS, FT_ALIQINS, D2_ABATINS, FT_VALINS , D2_UM     , D2_QUANT  , "
+	cQuery += CRLF + "          D2_BASEISS, D2_ALIQISS, D2_ABATISS, D2_ABATMAT, D2_VALISS , D2_ITEMCC , "
+	cQuery += CRLF + "          FT_BASECSL, FT_ALIQCSL, FT_VALCSL , D2_CUSTO1 , VRK_CHASSI, VRJ_CODCLI, VRJ_LOJA  , C6_XVLCOM , "
+	cQuery += CRLF + "          C6_TNATREC,  C6_NFORI , C6_FILIAL , C6_NUM    , VV3_TIPVEN, VV3_DESCRI, VRJ_CLIRET, VRK_OPCION, F2_VALBRUT ,D2_DESCZFR , D2_VRDICMS "
 
-	cQuery += " ORDER BY SD2.D2_FILIAL, SD2.D2_DOC, SD2.D2_SERIE, SD2.D2_CLIENTE, SD2.D2_LOJA " 						    + CRLF
+	cQuery += CRLF + " ORDER BY SD2.D2_FILIAL, SD2.D2_DOC, SD2.D2_SERIE, SD2.D2_CLIENTE, SD2.D2_LOJA " 						    + CRLF
 
 	cQuery := ChangeQuery(cQuery)
 
@@ -743,16 +751,16 @@ Static Function zRel0003( nVlIPIRegi, nVlIPIPres, cEspecie, cDoc, cSerie, cCodCl
 		( cAliasTRB )->( DbCloseArea() )
 	EndIf
 
-	cQry := " SELECT CDA_CODLAN, CDA_VALOR " 					+ CRLF
-	cQry += " FROM " + RetSQLName( 'CDA' ) + ' CDA ' 			+ CRLF
-	cQry += " WHERE CDA_FILIAL = '" + FWxFilial('SF2') + "' "	+ CRLF
-	cQry += " 	AND CDA_ESPECI = '" + cEspecie + "' "			+ CRLF
-	cQry += " 	AND CDA_NUMERO = '" + cDoc + "' "				+ CRLF
-	cQry += " 	AND CDA_SERIE = '" + cSerie + "' "				+ CRLF
-	cQry += " 	AND CDA_CLIFOR = '" + cCodCli + "' "			+ CRLF
-	cQry += " 	AND CDA_LOJA = '" + cCodLoja + "' "				+ CRLF
-	cQry += " 	AND CDA_NUMITE = '" + cItem + "' "				+ CRLF
-	cQry += " 	AND D_E_L_E_T_ = ' ' "							+ CRLF
+	cQry := CRLF + " SELECT CDA_CODLAN, CDA_VALOR "
+	cQry += CRLF + " FROM " + RetSQLName( 'CDA' ) + ' CDA '
+	cQry += CRLF + " WHERE  CDA_FILIAL = '" + FWxFilial('SF2') + "' "
+	cQry += CRLF + " 	AND CDA_ESPECI = '" + cEspecie + "' "
+	cQry += CRLF + " 	AND CDA_NUMERO = '" + cDoc     + "' "
+	cQry += CRLF + " 	AND CDA_SERIE  = '" + cSerie   + "' "
+	cQry += CRLF + " 	AND CDA_CLIFOR = '" + cCodCli  + "' "
+	cQry += CRLF + " 	AND CDA_LOJA   = '" + cCodLoja + "' "
+	cQry += CRLF + " 	AND CDA_NUMITE = '" + cItem    + "' "
+	cQry += CRLF + " 	AND D_E_L_E_T_ = ' ' "
 
 	cQry := ChangeQuery(cQry)
 

--- a/SIGAFIS/Relatorio/ZFISR008.prw
+++ b/SIGAFIS/Relatorio/ZFISR008.prw
@@ -49,6 +49,7 @@ Static Function zSelect2(nRadio)
 	Local cArquivo	:= ""
 	Private cPergR1	:= "ZFISR008R1"
 	Private cPergR2	:= "ZFISR008R2"
+	Private lMvNFLeiZF := SuperGetMV("MV_NFLEIZF",,.F.)
 
 	If nRadio == 1
 		If Pergunte( cPergR1	,.T.	)
@@ -65,6 +66,7 @@ Static Function zSelect2(nRadio)
 			EndIf
 		EndIf
 	EndIf
+
 Return()
 
 /*
@@ -80,6 +82,7 @@ Obs......:
 =====================================================================================
 */
 Static Function zRel001B(cArquivo)
+
 	Local cQuery		:= ""
 	Local cAliasTRB		:= GetNextAlias()
 	Local cTMPCanc		:= GetNextAlias()
@@ -114,6 +117,7 @@ Static Function zRel001B(cArquivo)
 	Local cCodNatur		:= ""
 	Local cCodChassi	:= ""
 	Local nVlCom		:= 0
+	Local nTotal 		:= 0
 	Local cNF           := " "
 	Local cTes          := " "
 	Local nTot01        := nTot02   := nTot03   := nTot04   := nTot05   := nTot06   := nTot07   := nTot08   := nTot09   := nTot10    := 0
@@ -160,7 +164,9 @@ Static Function zRel001B(cArquivo)
 	cQuery += " D1_BASEISS, D1_ALIQISS, D1_ABATISS, D1_ABATMAT, D1_VALISS, FT_CODBCC, FT_INDNTFR, "									+ CRLF
 	cQuery += " D1_VALFRE, D1_DESPESA, D1_CUSTO, D1_SEGURO, D1_VALACRS, D1_II, FT_ICMSCOM, D1_TNATREC, D1_CONHEC, "					+ CRLF
 	cQuery += " D1_PESO, FT_MVALPIS, FT_MVALCOF, W6_DTREG_D, W6_DI_NUM, YD_PER_II, VRK_OPCION, W9_TX_FOB, D1_CHASSI "							+ CRLF
+
 	cQuery += " FROM " + RetSQLName('SD1') + " SD1 "																				+ CRLF
+
 	cQuery += " INNER JOIN " + RetSQLName('SF1') + " SF1 "			 																+ CRLF
 	cQuery += " 	ON SF1.F1_FILIAL = '" + FWxFilial('SF1') + "' "																	+ CRLF
 	cQuery += " 	AND SF1.F1_DOC = SD1.D1_DOC " 																					+ CRLF
@@ -178,7 +184,7 @@ Static Function zRel001B(cArquivo)
 	cQuery += " 	ON SB1.B1_FILIAL = '" + FWxFilial('SB1') + "'  "																+ CRLF
 	cQuery += "		AND SB1.B1_COD = SD1.D1_COD  "	 																				+ CRLF
 	cQuery += "     AND SB1.D_E_L_E_T_ = ' '   " 																					+ CRLF
-
+	
 	If !Empty( MV_PAR20 )
 		cQuery += " 	AND SB1.B1_GRUPO = '" + MV_PAR20 + "' "																		+ CRLF
 	EndIf
@@ -264,10 +270,10 @@ Static Function zRel001B(cArquivo)
 
 	If !Empty( MV_PAR18 )
 		cQuery += " 	AND SD1.D1_CF = '" + MV_PAR18 + "' " 																		+ CRLF
-	EndIf  
+	EndIf
 
-    If !Empty( MV_PAR23) .OR. !Empty( MV_PAR24 )
-	   cQuery += " 	AND SD1.D1_CHASSI BETWEEN '" + MV_PAR23 + "' AND '" + MV_PAR24 + "' " 												+ CRLF
+    If !Empty( MV_PAR22) .OR. !Empty( MV_PAR23 )
+	   cQuery += " 	AND SD1.D1_CHASSI BETWEEN '" + MV_PAR22 + "' AND '" + MV_PAR23 + "' " 												+ CRLF
     EndIf
 
 	cQuery += " GROUP BY 	D1_FILIAL, D1_COD, D1_DOC, D1_SERIE, D1_TES, D1_CF, D1_FORNECE, D1_LOJA, D1_EMISSAO, D1_DTDIGIT, " 		+ CRLF
@@ -289,7 +295,9 @@ Static Function zRel001B(cArquivo)
 	cQuery += " D1_BASEISS, D1_ALIQISS, D1_ABATISS, D1_ABATMAT, D1_VALISS, FT_CODBCC, FT_INDNTFR, "									+ CRLF
 	cQuery += " D1_VALFRE, D1_DESPESA, D1_CUSTO, D1_SEGURO, D1_VALACRS, D1_II, FT_ICMSCOM, D1_TNATREC, D1_CONHEC,  "				+ CRLF
 	cQuery += " D1_PESO, FT_MVALPIS, FT_MVALCOF, W6_DTREG_D, W6_DI_NUM, YD_PER_II, VRK_OPCION, W9_TX_FOB, D1_CHASSI "							+ CRLF
-	cQuery += " ORDER BY SD1.D1_FILIAL, SD1.D1_EMISSAO, SD1.D1_DOC, SD1.D1_SERIE, SD1.D1_TES, SD1.D1_ITEM, SD1.D1_FORNECE, SD1.D1_LOJA "		+ CRLF
+
+	cQuery += " ORDER BY SD1.D1_FILIAL, SD1.D1_EMISSAO, SD1.D1_DOC, SD1.D1_SERIE, SD1.D1_TES, SD1.D1_ITEM, SD1.D1_FORNECE, SD1.D1_LOJA "+ CRLF
+
 	cQuery := ChangeQuery(cQuery)
 
 	// Executa a consulta.
@@ -631,6 +639,11 @@ Static Function zRel001B(cArquivo)
 			zRel003B(@nVlIPIRegi, @nVlIPIPres, (cAliasTRB)->F1_ESPECIE, (cAliasTRB)->F1_DOC, (cAliasTRB)->F1_SERIE,;
 					(cAliasTRB)->D1_FORNECE, (cAliasTRB)->D1_LOJA, (cAliasTRB)->D1_ITEM )
 
+			if !lMvNFLeiZF
+				nTotal := (cAliasTRB)->D1_TOTAL  
+			Else
+                nTotal := (cAliasTRB)->D1_TOTAL - ((cAliasTRB)->D1_DESCZFP + (cAliasTRB)->D1_DESCZFC) //--Valor Total Item
+			EndIF
             //Acumula Totais
 			aCampo01 :=	cCgcCpf
 			aCampo02 := cIncEst                                                                   				//--Insc.Estadual
@@ -638,7 +651,7 @@ Static Function zRel001B(cArquivo)
 			aCampo04 :=	cEstCli                                                                   				//--UF
 			aCampo05 := (cAliasTRB)->D1_TES                                                       				//--Tes
 			aCampo06 :=	Alltrim( (cAliasTRB)->F4_FINALID )                                        				//--Finalidade TES
-			nTot01   +=  iif(valtype((cAliasTRB)->D1_TOTAL)    = "N", (cAliasTRB)->D1_TOTAL   ,0) 				//--Valor Total Item
+			nTot01   +=  nTotal//iif(valtype((cAliasTRB)->D1_TOTAL)    = "N", (cAliasTRB)->D1_TOTAL   ,0) 				//--Valor Total Item
             aCampo07 :=   (cAliasTRB)->D1_CF                                                      				//--Cfop
 			nTot02   +=  iif(valtype((cAliasTRB)->FT_VALCONT)  = "N", (cAliasTRB)->FT_VALCONT ,0) 				//--Valor Contábil
 			nTot03   +=  iif(valtype((cAliasTRB)->FT_BASEICM)  = "N", (cAliasTRB)->FT_BASEICM ,0) 				//--Base ICMS
@@ -1089,6 +1102,9 @@ Static Function zRel002B(cArquivo)
 	Local nTotReg		:= ""
 	Local nVlIPIRegi	:= 0
 	Local nVlIPIPres	:= 0
+	Local nDesconto		:= 0
+	Local nDesVrIcms	:= 0
+	Local nTotal		:= 0
 
 	Local nTot01 := nTot02 := nTot03 := nTot04 := nTot05 := nTot06 := nTot07 := nTot08 := nTot09 := nTot10  := 0
 	Local nTot11 := nTot12 := nTot13 := nTot14 := nTot15 := nTot16 := nTot17 := nTot18 := nTot19 := nTot20  := 0
@@ -1121,7 +1137,7 @@ Static Function zRel002B(cArquivo)
 	cQuery += " B1_DESC, B1_XDESCL1, B1_GRUPO, B1_POSIPI, B1_CEST, B1_ORIGEM, B1_EX_NCM, D2_ITEM, "							+ CRLF
 	cQuery += " F2_ESPECIE,F2_CODNFE,F2_MENNOTA,F2_USERLGI,F2_USERLGA,F2_TIPO, FT_CHVNFE,F2_DOC, F2_SERIE, F2_FIMP,  " 		+ CRLF
 	cQuery += " FT_VALCONT, F2_FORMUL, D2_CONTA, D2_NFORI, D2_SERIORI, D2_PRUNIT,D2_TOTAL, "								+ CRLF
-	cQuery += " D2_DESC, FT_CLASFIS, D2_DESCZFP, D2_DESCZFC, D2_TIPO, "														+ CRLF
+	cQuery += " D2_DESC, FT_CLASFIS, D2_DESCZFP, D2_DESCZFC, D2_TIPO, D2_DESCON,"														+ CRLF
 	cQuery += " FT_BASEICM, FT_ALIQICM, FT_VALICM, C6_CHASSI, "																+ CRLF
 	cQuery += " FT_BASEIPI, FT_ALIQIPI, FT_VALIPI, FT_ARETPIS, FT_ARETCOF, FT_VRETPIS, FT_VRETCOF, FT_BRETPIS, "			+ CRLF
 	cQuery += " FT_BASERET, FT_ICMSRET, FT_DIFAL, FT_BRETCOF, "																+ CRLF
@@ -1133,7 +1149,7 @@ Static Function zRel002B(cArquivo)
 	cQuery += " FT_BASEINS,FT_ALIQINS,D2_ABATINS,FT_VALINS, D2_UM, D2_QUANT, "												+ CRLF
 	cQuery += " D2_BASEISS,D2_ALIQISS,D2_ABATISS,D2_ABATMAT,D2_VALISS, D2_ITEMCC, "											+ CRLF
 	cQuery += " FT_BASECSL,FT_ALIQCSL,FT_VALCSL, D2_CUSTO1, VRK_CHASSI, VRJ_CODCLI, VRJ_LOJA, C6_XVLCOM, "					+ CRLF
-	cQuery += " C6_TNATREC, C6_NFORI, C6_FILIAL, C6_NUM, VV3_TIPVEN, VV3_DESCRI, VRJ_CLIRET, VRK_OPCION "					+ CRLF
+	cQuery += " C6_TNATREC, C6_NFORI, C6_FILIAL, C6_NUM, VV3_TIPVEN, VV3_DESCRI, VRJ_CLIRET, VRK_OPCION,D2_DESCZFR , D2_VRDICMS " + CRLF
 	cQuery += " FROM   " + RetSQLName("SD2") + " SD2 " 																		+ CRLF
 	
 	cQuery += "	INNER JOIN " + RetSQLName("SF2") + " SF2 "																+ CRLF
@@ -1241,7 +1257,7 @@ Static Function zRel002B(cArquivo)
 	cQuery += " B1_DESC, B1_XDESCL1, B1_GRUPO, B1_POSIPI, B1_CEST, B1_ORIGEM, B1_EX_NCM, D2_ITEM, "							+ CRLF
 	cQuery += " F2_ESPECIE,F2_CODNFE,F2_MENNOTA,F2_USERLGI,F2_USERLGA,F2_TIPO, FT_CHVNFE,F2_DOC, F2_SERIE, F2_FIMP,  " 		+ CRLF
 	cQuery += " FT_VALCONT, F2_FORMUL, D2_CONTA, D2_NFORI, D2_SERIORI, D2_PRUNIT,D2_TOTAL, "								+ CRLF
-	cQuery += " D2_DESC, FT_CLASFIS, D2_DESCZFP, D2_DESCZFC, D2_TIPO, "														+ CRLF
+	cQuery += " D2_DESC, FT_CLASFIS, D2_DESCZFP, D2_DESCZFC, D2_TIPO,D2_DESCON, "														+ CRLF
 	cQuery += " FT_BASEICM, FT_ALIQICM, FT_VALICM, C6_CHASSI, "																+ CRLF
 	cQuery += " FT_BASEIPI, FT_ALIQIPI, FT_VALIPI, FT_ARETPIS, FT_ARETCOF, FT_VRETPIS, FT_VRETCOF, FT_BRETPIS, "			+ CRLF
 	cQuery += " FT_BASERET, FT_ICMSRET, FT_DIFAL, FT_BRETCOF, "																+ CRLF
@@ -1253,7 +1269,7 @@ Static Function zRel002B(cArquivo)
 	cQuery += " FT_BASEINS,FT_ALIQINS,D2_ABATINS,FT_VALINS, D2_UM, D2_QUANT, "												+ CRLF
 	cQuery += " D2_BASEISS,D2_ALIQISS,D2_ABATISS,D2_ABATMAT,D2_VALISS, D2_ITEMCC, "											+ CRLF
 	cQuery += " FT_BASECSL,FT_ALIQCSL,FT_VALCSL, D2_CUSTO1, VRK_CHASSI, VRJ_CODCLI, VRJ_LOJA, C6_XVLCOM,  "					+ CRLF
-	cQuery += " C6_TNATREC, C6_NFORI, C6_FILIAL, C6_NUM, VV3_TIPVEN, VV3_DESCRI, VRJ_CLIRET, VRK_OPCION "					+ CRLF
+	cQuery += " C6_TNATREC, C6_NFORI, C6_FILIAL, C6_NUM, VV3_TIPVEN, VV3_DESCRI, VRJ_CLIRET, VRK_OPCION,D2_DESCZFR, D2_VRDICMS"					+ CRLF
 
 	cQuery += " ORDER BY SD2.D2_FILIAL, SD2.D2_DOC, SD2.D2_SERIE, SD2.D2_CLIENTE, SD2.D2_LOJA , SD2.D2_TES" 						+ CRLF
 
@@ -1265,7 +1281,6 @@ Static Function zRel002B(cArquivo)
 	DbSelectArea((cAliasTRB))
 	nTotReg := Contar(cAliasTRB,"!Eof()")
 	(cAliasTRB)->(dbGoTop())
-	
 
 	If (cAliasTRB)->(!Eof())
 
@@ -1615,16 +1630,29 @@ Static Function zRel002B(cArquivo)
 					aCampo01 :=	cCgcCpf
 					aCampo02 :=	cCGCLocEnt
 					aCampo03 := cIncEst                              //--Insc.Estadual
+			nDesconto   := (cAliasTRB)->D2_DESCON
+        	nDesVrIcms  := 0
+			If  (cAliasTRB)->D2_VRDICMS > 0  .and. nDesconto >= (cAliasTRB)->D2_VRDICMS 
+				nDesVrIcms := (cAliasTRB)->D2_VRDICMS
+			EndIF
+        
+        	if !lMvNFLeiZF
+				nTotal := ((cAliasTRB)->D2_TOTAL  + nDesconto + (cAliasTRB)->D2_DESCZFR ) - nDesVrIcms 
+			Else
+                nTotal := ((cAliasTRB)->D2_TOTAL  + nDesconto + (cAliasTRB)->D2_DESCZFR ) - ( (cAliasTRB)->D2_DESCZFP + (cAliasTRB)->D2_DESCZFC + nDesVrIcms )  //--Valor Total Item
+			EndIF
+			nVlrDesc := nDesconto
+
 					aCampo04 :=	cTpPessoa                            //--Pessoa Fisica/Juridica
 					aCampo05 :=	cEstCli                              //--UF
 					aCampo06 := (cAliasTRB)->D2_TES                  //--Tes
 					aCampo07 :=	Alltrim( (cAliasTRB)->F4_FINALID )   //--Finalidade TES
-					nTot01   +=  iif(valtype((cAliasTRB)->D2_TOTAL)    = "N", (cAliasTRB)->D2_TOTAL   ,0) //--Valor Total Item
+					nTot01   +=  nTotal//iif(valtype((cAliasTRB)->D2_TOTAL)    = "N", (cAliasTRB)->D2_TOTAL   ,0) //--Valor Total Item
 					aCampo08 := (cAliasTRB)->D2_CF    //--Cfop
 					nTot02   +=  iif(valtype((cAliasTRB)->FT_VALCONT)  = "N", (cAliasTRB)->FT_VALCONT ,0) //--Valor Contábil
-					nTot03   +=  iif(valtype((cAliasTRB)->FT_BASEICM)  = "N", (cAliasTRB)->FT_BASEICM ,0) //--Base ICMS
-					aCAmpo09 := (cAliasTRB)->FT_ALIQICM   //--Aliq. ICMS
-					nTot04   +=  iif(valtype((cAliasTRB)->FT_VALICM)   = "N", (cAliasTRB)->FT_VALICM  ,0) //--Valor ICMS
+					nTot03   += iif( Alltrim((cAliasTRB)->F2_ESPECIE) <> "RPS",( iif(valtype((cAliasTRB)->FT_BASEICM)  = "N", (cAliasTRB)->FT_BASEICM ,0) ),0) //--Base ICMS
+					aCAmpo09 := iif( Alltrim((cAliasTRB)->F2_ESPECIE) <> "RPS",((cAliasTRB)->FT_ALIQICM ),0)  //--Aliq. ICMS
+					nTot04   += iif( Alltrim((cAliasTRB)->F2_ESPECIE) <> "RPS",( iif(valtype((cAliasTRB)->FT_VALICM)   = "N", (cAliasTRB)->FT_VALICM  ,0) ),0) //--Valor ICMS
 					aCAmpo10 := (cAliasTRB)->C6_XVLCOM    //--Comissão
 					nTot05   +=  iif(valtype((cAliasTRB)->FT_BASEIPI)  = "N", (cAliasTRB)->FT_BASEIPI ,0) //--Base IPI
 					aCampo11 := (cAliasTRB)->FT_ALIQIPI    //--Aliq. IPI

--- a/SIGAFIS/Relatorio/ZFISR011.prw
+++ b/SIGAFIS/Relatorio/ZFISR011.prw
@@ -3,11 +3,11 @@
 
 //----------------------------------------------------------
 User Function ZFISR011()
-    Local oReport
-    Local oSection
-    Private cAliasTMP  := GetNextAlias()
-    Private lMvNFLeiZF := SuperGetMV("MV_NFLEIZF",,.F.)
-	oReport:= TReport():New("ZFISR011",;
+    Local oReport,  oSection
+
+    Private cAliasTMP := GetNextAlias()
+
+	oReport:= TReport():New("ZFISR005",;
                             "Saidas",;
                             "ZFISR001R2",;
                             {|oReport|  ReportPrint(oReport)},;
@@ -422,30 +422,22 @@ Static Function ReportPrint(oReport)
         oSection:Cell( "EstCli"      ):SetValue( cEstCli                            ) //--UF
         oSection:Cell( "D2_TES"      ):SetValue( (cAliasTMP)->D2_TES                ) //--Tes
         oSection:Cell( "F4_FINALID"  ):SetValue( Alltrim( (cAliasTMP)->F4_FINALID ) ) //--Finalidade TES
-        oSection:Cell( "B1_ORIGEM"   ):SetValue( AllTrim( (cAliasTMP)->B1_ORIGEM  ) ) //--Origem do Produto
-        oSection:Cell( "B1_POSIPI"   ):SetValue( AllTrim( (cAliasTMP)->B1_POSIPI  ) ) //--NCM
-        oSection:Cell( "B1_EX_NCM"   ):SetValue( AllTrim( (cAliasTMP)->B1_EX_NCM  ) ) //--Ex-NCM
-        oSection:Cell( "ModVei"      ):SetValue( AllTrim( cModVei                 ) ) //--Modelo Veículo
+        oSection:Cell( "B1_ORIGEM"   ):SetValue( AllTrim( (cAliasTMP)->B1_ORIGEM ) ) //--Origem do Produto
+        oSection:Cell( "B1_POSIPI"   ):SetValue( AllTrim( (cAliasTMP)->B1_POSIPI ) ) //--NCM
+        oSection:Cell( "B1_EX_NCM"   ):SetValue( AllTrim( (cAliasTMP)->B1_EX_NCM ) ) //--Ex-NCM
+        oSection:Cell( "ModVei"      ):SetValue( AllTrim( cModVei ) ) //--Modelo Veículo
         oSection:Cell( "VRK_OPCION"  ):SetValue( AllTrim( (cAliasTMP)->VRK_OPCION ) ) //--Opcional
         oSection:Cell( "B1_GRUPO"    ):SetValue( AllTrim( (cAliasTMP)->B1_GRUPO   ) ) //--Grupo\Linha
         oSection:Cell( "BM_DESC"     ):SetValue( AllTrim( Posicione("SBM",1,xFilial("SBM")+(cAliasTMP)->B1_GRUPO,"BM_DESC") ) ) //--Descrição do Grupo
-       
-        nDesconto   := (cAliasTMP)->D2_DESCON
-        nDesVrIcms  := 0
-		If  (cAliasTMP)->D2_VRDICMS > 0  .and. nDesconto >= (ccAliasTMP)->D2_VRDICMS 
-			nDesVrIcms := (ccAliasTMP)->D2_VRDICMS
-		EndIF
-        
-        oSection:Cell( "D2_TOTAL"    ):SetValue( iif(!lMvNFLeiZF,((cAliasTMP)->D2_TOTAL ) + nDesconto + (cAliasTMP)->D2_DESCZFR - nDesVrIcms ,;
-                                                                 ((cAliasTMP)->D2_TOTAL ) + nDesconto + (cAliasTMP)->D2_DESCZFR )-((cAliasTMP)->D2_DESCZFP+(cAliasTMP)->D2_DESCZFC+nDesVrIcms))  //--Valor Total Item
-        oSection:Cell( "D2_PRUNIT"   ):SetValue( (cAliasTMP)->D2_PRUNIT  ) //--Valor Unit. Item
-        oSection:Cell( "D2_DESCON"   ):SetValue( (cAliasTMP)->D2_DESCON  ) //--Valor Desc. Item
-        oSection:Cell( "D2_CF"       ):SetValue( (cAliasTMP)->D2_CF      ) //--Cfop
+        oSection:Cell( "D2_TOTAL"    ):SetValue( (cAliasTMP)->D2_TOTAL ) //--Valor Total Item
+        oSection:Cell( "D2_PRUNIT"   ):SetValue( (cAliasTMP)->D2_PRUNIT ) //--Valor Unit. Item
+        oSection:Cell( "D2_DESCON"   ):SetValue( (cAliasTMP)->D2_DESCON ) //--Valor Desc. Item
+        oSection:Cell( "D2_CF"       ):SetValue( (cAliasTMP)->D2_CF ) //--Cfop
         oSection:Cell( "FT_VALCONT"  ):SetValue( (cAliasTMP)->FT_VALCONT ) //--Valor Contábil
         oSection:Cell( "FT_BASEICM"  ):SetValue( (cAliasTMP)->FT_BASEICM ) //--Base ICMS
         oSection:Cell( "FT_ALIQICM"  ):SetValue( (cAliasTMP)->FT_ALIQICM ) //--Aliq. ICMS
-        oSection:Cell( "FT_VALICM"   ):SetValue( (cAliasTMP)->FT_VALICM  ) //--Valor ICMS
-        oSection:Cell( "C6_XVLCOM"   ):SetValue( (cAliasTMP)->C6_XVLCOM  ) //--Comissão
+        oSection:Cell( "FT_VALICM"   ):SetValue( (cAliasTMP)->FT_VALICM ) //--Valor ICMS
+        oSection:Cell( "C6_XVLCOM"   ):SetValue( (cAliasTMP)->C6_XVLCOM ) //--Comissão
         oSection:Cell( "FT_BASEIPI"  ):SetValue( (cAliasTMP)->FT_BASEIPI ) //--Base IPI
         oSection:Cell( "FT_ALIQIPI"  ):SetValue( (cAliasTMP)->FT_ALIQIPI ) //--Aliq. IPI
         oSection:Cell( "FT_VALIPI"   ):SetValue( (cAliasTMP)->FT_VALIPI  ) //--Valor IPI
@@ -689,25 +681,25 @@ Static Function zTmpRadio3()
 		cQuery += CRLF + " 	AND SD2.D2_CF = '" + MV_PAR16 + "' "
 	EndIf  
 
-	cQuery += CRLF + " GROUP BY D2_FILIAL , D2_COD    , D2_DOC    , D2_SERIE  , D2_TES    , D2_CF    , D2_CLIENTE, D2_LOJA   , D2_EMISSAO, D2_ITEMPV, "
-	cQuery += CRLF + "          F4_FINALID, F4_TEXTO  , FT_CTIPI  , FT_CSTPIS , FT_CSTCOF , F4_ICM   , F4_IPI    , F4_CREDICM, F4_CREDIPI, F4_DUPLIC, "
-	cQuery += CRLF + "          B1_DESC   , B1_XDESCL1, B1_GRUPO  , B1_POSIPI , B1_CEST   , B1_ORIGEM, B1_EX_NCM , B1_EX_NBM , D2_ITEM   , "
-	cQuery += CRLF + "          F2_ESPECIE, F2_CODNFE , F2_MENNOTA, F2_USERLGI, F2_USERLGA, F2_TIPO  , FT_CHVNFE , F2_DOC    , F2_SERIE  , F2_FIMP,  "
-	cQuery += CRLF + "          FT_VALCONT, F2_FORMUL , D2_CONTA  , D2_NFORI  , D2_SERIORI, D2_PRUNIT, D2_TOTAL  , "
-	cQuery += CRLF + "          D2_DESPESA, D2_SEGURO , D2_VALFRE , D2_DESCON ,"
-    cQuery += CRLF + "          FT_CLASFIS, D2_DESCZFP, D2_DESCZFC, D2_TIPO   ,"
-	cQuery += CRLF + "          FT_BASEICM, FT_ALIQICM, FT_VALICM , C6_CHASSI ,"
-	cQuery += CRLF + "          FT_BASEIPI, FT_ALIQIPI, FT_VALIPI , FT_BRETPIS, FT_ARETPIS, FT_VRETPIS, FT_BRETCOF, FT_ARETCOF, FT_VRETCOF, "
-	cQuery += CRLF + "          FT_BASERET, FT_ICMSRET, FT_DIFAL  , " 
- 	cQuery += CRLF + "          D2_BASIMP6, D2_ALQIMP6, D2_VALIMP6, " 
- 	cQuery += CRLF + "          D2_BASIMP5, D2_ALQIMP5, D2_VALIMP5, " 
- 	cQuery += CRLF + "          FT_BASEPIS, FT_ALIQPIS, FT_VALPIS , F2_TOTFED , F2_TOTEST , "
-	cQuery += CRLF + "          FT_BASECOF, FT_ALIQCOF, FT_VALCOF , FT_BASECF3, FT_ALIQCF3, FT_VALCF3 , FT_BASEPS3, FT_ALIQPS3, FT_VALPS3, "
-	cQuery += CRLF + "          FT_BASEIRR, FT_ALIQIRR, FT_VALIRR , F3_OUTRIPI, F3_ISENIPI, F3_OUTRICM, F3_ISENICM, "
-	cQuery += CRLF + "          FT_BASEINS, FT_ALIQINS, D2_ABATINS, FT_VALINS , D2_UM     , D2_QUANT  , "
-	cQuery += CRLF + "          D2_BASEISS, D2_ALIQISS, D2_ABATISS, D2_ABATMAT, D2_VALISS , D2_ITEMCC , "
-	cQuery += CRLF + "          FT_BASECSL, FT_ALIQCSL, FT_VALCSL , D2_CUSTO1 , VRK_CHASSI, VRJ_CODCLI, VRJ_LOJA  , C6_XVLCOM , "
-	cQuery += CRLF + "          C6_TNATREC,  C6_NFORI , C6_FILIAL , C6_NUM    , VV3_TIPVEN, VV3_DESCRI, VRJ_CLIRET, VRK_OPCION, F2_VALBRUT ,D2_DESCZFR , D2_VRDICMS "
+	cQuery += " GROUP BY D2_FILIAL, D2_COD, D2_DOC,D2_SERIE, D2_TES, D2_CF,D2_CLIENTE,D2_LOJA,D2_EMISSAO, D2_ITEMPV, "		+ CRLF
+	cQuery += " F4_FINALID, F4_TEXTO, FT_CTIPI, FT_CSTPIS, FT_CSTCOF, F4_ICM, F4_IPI, F4_CREDICM, F4_CREDIPI, F4_DUPLIC, "	+ CRLF
+	cQuery += " B1_DESC, B1_XDESCL1, B1_GRUPO, B1_POSIPI, B1_CEST, B1_ORIGEM, B1_EX_NCM, B1_EX_NBM, D2_ITEM, "							+ CRLF
+	cQuery += " F2_ESPECIE,F2_CODNFE,F2_MENNOTA,F2_USERLGI,F2_USERLGA,F2_TIPO, FT_CHVNFE,F2_DOC, F2_SERIE, F2_FIMP,  " 		+ CRLF
+	cQuery += " FT_VALCONT, F2_FORMUL, D2_CONTA, D2_NFORI, D2_SERIORI, D2_PRUNIT,D2_TOTAL, "								+ CRLF
+	cQuery += " D2_DESPESA, D2_SEGURO, D2_VALFRE, D2_DESCON, "	                                                            + CRLF
+    cQuery += " FT_CLASFIS, D2_DESCZFP, D2_DESCZFC, D2_TIPO, "														        + CRLF
+	cQuery += " FT_BASEICM, FT_ALIQICM, FT_VALICM, C6_CHASSI, "																+ CRLF
+	cQuery += " FT_BASEIPI, FT_ALIQIPI, FT_VALIPI, FT_BRETPIS, FT_ARETPIS, FT_VRETPIS, FT_BRETCOF, FT_ARETCOF, FT_VRETCOF, "+ CRLF
+	cQuery += " FT_BASERET, FT_ICMSRET, FT_DIFAL, "																			+ CRLF
+	cQuery += " D2_BASIMP6,D2_ALQIMP6,D2_VALIMP6,   " 																		+ CRLF
+	cQuery += " D2_BASIMP5,D2_ALQIMP5,D2_VALIMP5,   " 																		+ CRLF
+	cQuery += " FT_BASEPIS,FT_ALIQPIS,FT_VALPIS, F2_TOTFED, F2_TOTEST, " 													+ CRLF
+	cQuery += " FT_BASECOF,FT_ALIQCOF,FT_VALCOF, FT_BASECF3, FT_ALIQCF3, FT_VALCF3, FT_BASEPS3, FT_ALIQPS3, FT_VALPS3, "	+ CRLF
+	cQuery += " FT_BASEIRR,FT_ALIQIRR,FT_VALIRR, F3_OUTRIPI, F3_ISENIPI, F3_OUTRICM, F3_ISENICM,  "							+ CRLF
+	cQuery += " FT_BASEINS,FT_ALIQINS,D2_ABATINS,FT_VALINS, D2_UM, D2_QUANT, "												+ CRLF
+	cQuery += " D2_BASEISS,D2_ALIQISS,D2_ABATISS,D2_ABATMAT,D2_VALISS, D2_ITEMCC, "											+ CRLF
+	cQuery += " FT_BASECSL,FT_ALIQCSL,FT_VALCSL, D2_CUSTO1, VRK_CHASSI, VRJ_CODCLI, VRJ_LOJA, C6_XVLCOM,  "					+ CRLF
+	cQuery += " C6_TNATREC, C6_NFORI, C6_FILIAL, C6_NUM, VV3_TIPVEN, VV3_DESCRI, VRJ_CLIRET, VRK_OPCION, F2_VALBRUT "		+ CRLF
 
 	cQuery += CRLF + " ORDER BY SD2.D2_FILIAL, SD2.D2_DOC, SD2.D2_SERIE, SD2.D2_CLIENTE, SD2.D2_LOJA "
 

--- a/SIGAFIS/Relatorio/ZFISR011.prw
+++ b/SIGAFIS/Relatorio/ZFISR011.prw
@@ -3,21 +3,21 @@
 
 //----------------------------------------------------------
 User Function ZFISR011()
-    Local oReport,  oSection
-
-    Private cAliasTMP := GetNextAlias()
-
-	oReport:= TReport():New("ZFISR005",;
+    Local oReport
+    Local oSection
+    Private cAliasTMP  := GetNextAlias()
+    Private lMvNFLeiZF := SuperGetMV("MV_NFLEIZF",,.F.)
+	oReport:= TReport():New("ZFISR011",;
                             "Saidas",;
                             "ZFISR001R2",;
                             {|oReport|  ReportPrint(oReport)},;
                             "Este relatorio efetua a impressão das notas fiscais de saida")
-	oReport:HideParamPage()   // Desabilita a impressao da pagina de parametros.
-    oReport:HideHeader() //--Define que não será impresso o cabeçalho padrão da página
-    oReport:HideFooter() //--Define que não será impresso o rodapé padrão da página
-    oReport:SetDevice(4) //--Define o tipo de impressão selecionado. Opções: 1-Arquivo,2-Impressora,3-Email,4-Planilha, 5-Html e 6-PDF
-    oReport:SetPreview(.T.) //--Define se será apresentada a visualização do relatório antes da impressão física
-    oReport:SetEnvironment(2) //--Define o ambiente para impressão 	Ambiente: 1-Server e 2-Client
+	oReport:HideParamPage()     // Desabilita a impressao da pagina de parametros.
+    oReport:HideHeader()        //--Define que não será impresso o cabeçalho padrão da página
+    oReport:HideFooter()        //--Define que não será impresso o rodapé padrão da página
+    oReport:SetDevice(4)        //--Define o tipo de impressão selecionado. Opções: 1-Arquivo,2-Impressora,3-Email,4-Planilha, 5-Html e 6-PDF
+    oReport:SetPreview(.T.)     //--Define se será apresentada a visualização do relatório antes da impressão física
+    oReport:SetEnvironment(2)   //--Define o ambiente para impressão 	Ambiente: 1-Server e 2-Client
     //oReport:SetEdit(.T.) 
 	
 	//Verifica os parâmetros selecionados via Pergunte
@@ -185,9 +185,6 @@ Static Function ReportPrint(oReport)
 	Local cTpPessoa		:= ""
 	Local cTpNF			:= ""
 	Local cNumPed 		:= ""
-	Local nVlrFrete 	:= 0
-	Local nVlrSeguro	:= 0
-	Local nVlrDesp		:= 0
 	Local cMenNota		:= ""
 	Local cMenPad		:= ""
 	Local cNaturez		:= ""
@@ -196,9 +193,13 @@ Static Function ReportPrint(oReport)
 	Local cCGCLocEnt	:= ""
 	Local cNomLocEnt	:= ""
 	Local cUFLocEnt		:= "" 
+	Local nVlrFrete 	:= 0
+	Local nVlrSeguro	:= 0
+	Local nVlrDesp		:= 0
 	Local nVlIPIRegi	:= 0
 	Local nVlIPIPres	:= 0
-	
+	Local nDesconto     := 0
+    Local nDesVrIcms    := 0
     //Monta Tmp
     zTmpRadio3()
 
@@ -414,135 +415,143 @@ Static Function ReportPrint(oReport)
         zRel0003(@nVlIPIRegi, @nVlIPIPres, (cAliasTMP)->F2_ESPECIE, (cAliasTMP)->F2_DOC, (cAliasTMP)->F2_SERIE,;
                 (cAliasTMP)->D2_CLIENTE, (cAliasTMP)->D2_LOJA, (cAliasTMP)->D2_ITEM )	
 
-        oSection:Cell( "CgcCpf"      ):SetValue( cCgcCpf     ) //--Cnpj/Cpf
-        oSection:Cell( "CGCLocEnt"   ):SetValue( cCGCLocEnt  ) //--CNPJ Loc. Entr.
-        oSection:Cell( "IncEst"      ):SetValue( cIncEst     ) //--Insc.Estadual
-        oSection:Cell( "TpPessoa"    ):SetValue( cTpPessoa   ) //--Pessoa Fisica/Juridica
-        oSection:Cell( "EstCli"      ):SetValue( cEstCli     ) //--UF
-        oSection:Cell( "D2_TES"      ):SetValue( (cAliasTMP)->D2_TES ) //--Tes
+        oSection:Cell( "CgcCpf"      ):SetValue( cCgcCpf                            ) //--Cnpj/Cpf
+        oSection:Cell( "CGCLocEnt"   ):SetValue( cCGCLocEnt                         ) //--CNPJ Loc. Entr.
+        oSection:Cell( "IncEst"      ):SetValue( cIncEst                            ) //--Insc.Estadual
+        oSection:Cell( "TpPessoa"    ):SetValue( cTpPessoa                          ) //--Pessoa Fisica/Juridica
+        oSection:Cell( "EstCli"      ):SetValue( cEstCli                            ) //--UF
+        oSection:Cell( "D2_TES"      ):SetValue( (cAliasTMP)->D2_TES                ) //--Tes
         oSection:Cell( "F4_FINALID"  ):SetValue( Alltrim( (cAliasTMP)->F4_FINALID ) ) //--Finalidade TES
-        oSection:Cell( "B1_ORIGEM"   ):SetValue( AllTrim( (cAliasTMP)->B1_ORIGEM ) ) //--Origem do Produto
-        oSection:Cell( "B1_POSIPI"   ):SetValue( AllTrim( (cAliasTMP)->B1_POSIPI ) ) //--NCM
-        oSection:Cell( "B1_EX_NCM"   ):SetValue( AllTrim( (cAliasTMP)->B1_EX_NCM ) ) //--Ex-NCM
-        oSection:Cell( "ModVei"      ):SetValue( AllTrim( cModVei ) ) //--Modelo Veículo
+        oSection:Cell( "B1_ORIGEM"   ):SetValue( AllTrim( (cAliasTMP)->B1_ORIGEM  ) ) //--Origem do Produto
+        oSection:Cell( "B1_POSIPI"   ):SetValue( AllTrim( (cAliasTMP)->B1_POSIPI  ) ) //--NCM
+        oSection:Cell( "B1_EX_NCM"   ):SetValue( AllTrim( (cAliasTMP)->B1_EX_NCM  ) ) //--Ex-NCM
+        oSection:Cell( "ModVei"      ):SetValue( AllTrim( cModVei                 ) ) //--Modelo Veículo
         oSection:Cell( "VRK_OPCION"  ):SetValue( AllTrim( (cAliasTMP)->VRK_OPCION ) ) //--Opcional
-        oSection:Cell( "B1_GRUPO"    ):SetValue( AllTrim( (cAliasTMP)->B1_GRUPO ) ) //--Grupo\Linha
+        oSection:Cell( "B1_GRUPO"    ):SetValue( AllTrim( (cAliasTMP)->B1_GRUPO   ) ) //--Grupo\Linha
         oSection:Cell( "BM_DESC"     ):SetValue( AllTrim( Posicione("SBM",1,xFilial("SBM")+(cAliasTMP)->B1_GRUPO,"BM_DESC") ) ) //--Descrição do Grupo
-        oSection:Cell( "D2_TOTAL"    ):SetValue( (cAliasTMP)->D2_TOTAL ) //--Valor Total Item
-        oSection:Cell( "D2_PRUNIT"   ):SetValue( (cAliasTMP)->D2_PRUNIT ) //--Valor Unit. Item
-        oSection:Cell( "D2_DESCON"   ):SetValue( (cAliasTMP)->D2_DESCON ) //--Valor Desc. Item
-        oSection:Cell( "D2_CF"       ):SetValue( (cAliasTMP)->D2_CF ) //--Cfop
+       
+        nDesconto   := (cAliasTMP)->D2_DESCON
+        nDesVrIcms  := 0
+		If  (cAliasTMP)->D2_VRDICMS > 0  .and. nDesconto >= (ccAliasTMP)->D2_VRDICMS 
+			nDesVrIcms := (ccAliasTMP)->D2_VRDICMS
+		EndIF
+        
+        oSection:Cell( "D2_TOTAL"    ):SetValue( iif(!lMvNFLeiZF,((cAliasTMP)->D2_TOTAL ) + nDesconto + (cAliasTMP)->D2_DESCZFR - nDesVrIcms ,;
+                                                                 ((cAliasTMP)->D2_TOTAL ) + nDesconto + (cAliasTMP)->D2_DESCZFR )-((cAliasTMP)->D2_DESCZFP+(cAliasTMP)->D2_DESCZFC+nDesVrIcms))  //--Valor Total Item
+        oSection:Cell( "D2_PRUNIT"   ):SetValue( (cAliasTMP)->D2_PRUNIT  ) //--Valor Unit. Item
+        oSection:Cell( "D2_DESCON"   ):SetValue( (cAliasTMP)->D2_DESCON  ) //--Valor Desc. Item
+        oSection:Cell( "D2_CF"       ):SetValue( (cAliasTMP)->D2_CF      ) //--Cfop
         oSection:Cell( "FT_VALCONT"  ):SetValue( (cAliasTMP)->FT_VALCONT ) //--Valor Contábil
         oSection:Cell( "FT_BASEICM"  ):SetValue( (cAliasTMP)->FT_BASEICM ) //--Base ICMS
         oSection:Cell( "FT_ALIQICM"  ):SetValue( (cAliasTMP)->FT_ALIQICM ) //--Aliq. ICMS
-        oSection:Cell( "FT_VALICM"   ):SetValue( (cAliasTMP)->FT_VALICM ) //--Valor ICMS
-        oSection:Cell( "C6_XVLCOM"   ):SetValue( (cAliasTMP)->C6_XVLCOM ) //--Comissão
+        oSection:Cell( "FT_VALICM"   ):SetValue( (cAliasTMP)->FT_VALICM  ) //--Valor ICMS
+        oSection:Cell( "C6_XVLCOM"   ):SetValue( (cAliasTMP)->C6_XVLCOM  ) //--Comissão
         oSection:Cell( "FT_BASEIPI"  ):SetValue( (cAliasTMP)->FT_BASEIPI ) //--Base IPI
         oSection:Cell( "FT_ALIQIPI"  ):SetValue( (cAliasTMP)->FT_ALIQIPI ) //--Aliq. IPI
-        oSection:Cell( "FT_VALIPI"   ):SetValue( (cAliasTMP)->FT_VALIPI ) //--Valor IPI
-        oSection:Cell( "VlIPIRegi"   ):SetValue( nVlIPIRegi ) //--Credito_Regional IPI
-        oSection:Cell( "VlIPIPres"   ):SetValue( nVlIPIPres ) //--Credito_Presumido IPI/Frete
+        oSection:Cell( "FT_VALIPI"   ):SetValue( (cAliasTMP)->FT_VALIPI  ) //--Valor IPI
+        oSection:Cell( "VlIPIRegi"   ):SetValue( nVlIPIRegi              ) //--Credito_Regional IPI
+        oSection:Cell( "VlIPIPres"   ):SetValue( nVlIPIPres              ) //--Credito_Presumido IPI/Frete
         oSection:Cell( "FT_BASERET"  ):SetValue( (cAliasTMP)->FT_BASERET ) //--Base Subst
         oSection:Cell( "FT_ICMSRET"  ):SetValue( (cAliasTMP)->FT_ICMSRET ) //--Valor Subst
         oSection:Cell( "FT_BASEPIS"  ):SetValue( (cAliasTMP)->FT_BASEPIS ) //--Base Pis Apuração
         oSection:Cell( "FT_ALIQPIS"  ):SetValue( (cAliasTMP)->FT_ALIQPIS ) //--Aliq. Pis Apuração
-        oSection:Cell( "FT_VALPIS"   ):SetValue( (cAliasTMP)->FT_VALPIS ) //--Valor Pis Apuração
+        oSection:Cell( "FT_VALPIS"   ):SetValue( (cAliasTMP)->FT_VALPIS  ) //--Valor Pis Apuração
         oSection:Cell( "FT_BASECOF"  ):SetValue( (cAliasTMP)->FT_BASECOF ) //--Base Cofins Apuração
         oSection:Cell( "FT_ALIQCOF"  ):SetValue( (cAliasTMP)->FT_ALIQCOF ) //--Aliq. Cofins Apuração
-        oSection:Cell( "FT_VALCOF"   ):SetValue( (cAliasTMP)->FT_VALCOF ) //--Valor Cofins Apuração
+        oSection:Cell( "FT_VALCOF"   ):SetValue( (cAliasTMP)->FT_VALCOF  ) //--Valor Cofins Apuração
         oSection:Cell( "FT_BASEPS3"  ):SetValue( (cAliasTMP)->FT_BASEPS3 ) //--Base Pis ST ZFM
         oSection:Cell( "FT_ALIQPS3"  ):SetValue( (cAliasTMP)->FT_ALIQPS3 ) //--Aliq. Pis ST ZFM
-        oSection:Cell( "FT_VALPS3"   ):SetValue( (cAliasTMP)->FT_VALPS3 ) //--Vl. Pis ST ZFM
+        oSection:Cell( "FT_VALPS3"   ):SetValue( (cAliasTMP)->FT_VALPS3  ) //--Vl. Pis ST ZFM
         oSection:Cell( "FT_BASECF3"  ):SetValue( (cAliasTMP)->FT_BASECF3 ) //--Base Cof ST ZFM
         oSection:Cell( "FT_ALIQCF3"  ):SetValue( (cAliasTMP)->FT_ALIQCF3 ) //--Aliq. Cof ST ZFM
-        oSection:Cell( "FT_VALCF3"   ):SetValue( (cAliasTMP)->FT_VALCF3 ) //--Vl. Cof ST ZFM
-        oSection:Cell( "FT_DIFAL"    ):SetValue( (cAliasTMP)->FT_DIFAL ) //--ICMS Difal
+        oSection:Cell( "FT_VALCF3"   ):SetValue( (cAliasTMP)->FT_VALCF3  ) //--Vl. Cof ST ZFM
+        oSection:Cell( "FT_DIFAL"    ):SetValue( (cAliasTMP)->FT_DIFAL   ) //--ICMS Difal
         oSection:Cell( "FT_CLASFIS"  ):SetValue( (cAliasTMP)->FT_CLASFIS ) //--CST ICMS
-        oSection:Cell( "FT_CTIPI"    ):SetValue( (cAliasTMP)->FT_CTIPI ) //--CST IPI
-        oSection:Cell( "FT_CSTPIS"   ):SetValue( (cAliasTMP)->FT_CSTPIS ) //--CST PIS
-        oSection:Cell( "FT_CSTCOF"   ):SetValue( (cAliasTMP)->FT_CSTCOF ) //--CST COFINS
-        oSection:Cell( "F4_ICM"      ):SetValue( (cAliasTMP)->F4_ICM ) //--Calcula ICMS
+        oSection:Cell( "FT_CTIPI"    ):SetValue( (cAliasTMP)->FT_CTIPI   ) //--CST IPI
+        oSection:Cell( "FT_CSTPIS"   ):SetValue( (cAliasTMP)->FT_CSTPIS  ) //--CST PIS
+        oSection:Cell( "FT_CSTCOF"   ):SetValue( (cAliasTMP)->FT_CSTCOF  ) //--CST COFINS
+        oSection:Cell( "F4_ICM"      ):SetValue( (cAliasTMP)->F4_ICM     ) //--Calcula ICMS
         oSection:Cell( "F4_CREDICM"  ):SetValue( (cAliasTMP)->F4_CREDICM ) //--Credita ICMS
-        oSection:Cell( "F4_IPI"      ):SetValue( (cAliasTMP)->F4_IPI ) //--Calcula IPI
+        oSection:Cell( "F4_IPI"      ):SetValue( (cAliasTMP)->F4_IPI     ) //--Calcula IPI
         oSection:Cell( "F4_CREDIPI"  ):SetValue( (cAliasTMP)->F4_CREDIPI ) //--Credita IPI
-        oSection:Cell( "D2_DOC"      ):SetValue( (cAliasTMP)->D2_DOC ) //--Nota Fiscal
+        oSection:Cell( "D2_DOC"      ):SetValue( (cAliasTMP)->D2_DOC     ) //--Nota Fiscal
         oSection:Cell( "NfPref"      ):SetValue( IIF( AllTrim( (cAliasTMP)->F2_ESPECIE ) == 'NFS', (cAliasTMP)->D2_DOC, "" ) ) //--Nf. Prefeitura
-        oSection:Cell( "D2_SERIE"    ):SetValue( (cAliasTMP)->D2_SERIE ) //--Série
+        oSection:Cell( "D2_SERIE"    ):SetValue( (cAliasTMP)->D2_SERIE   ) //--Série
         oSection:Cell( "F2_ESPECIE"  ):SetValue( (cAliasTMP)->F2_ESPECIE ) //--Espécie
         oSection:Cell( "ModNot"      ):SetValue( AModNot( (cAliasTMP)->F2_ESPECIE ) ) //--Modelo
         oSection:Cell( "D2_EMISSAO"  ):SetValue( IIF( Empty( SToD( (cAliasTMP)->D2_EMISSAO ) ), "", SToD( (cAliasTMP)->D2_EMISSAO ) ) ) //--Dt. de Emissão
         oSection:Cell( "D2_CLIENTE"  ):SetValue( (cAliasTMP)->D2_CLIENTE ) //--Cliente\Fornecedor
-        oSection:Cell( "D2_LOJA"     ):SetValue( (cAliasTMP)->D2_LOJA ) //--Loja
-        oSection:Cell( "CliFor"      ):SetValue( cCliFor ) //--Nome
+        oSection:Cell( "D2_LOJA"     ):SetValue( (cAliasTMP)->D2_LOJA    ) //--Loja
+        oSection:Cell( "CliFor"      ):SetValue( cCliFor                 ) //--Nome
         oSection:Cell( "C6_CHASSI"   ):SetValue( AllTrim( (cAliasTMP)->C6_CHASSI ) ) //--Chassi
-        oSection:Cell( "D2_COD"      ):SetValue( (cAliasTMP)->D2_COD ) //--Cód.Produto
+        oSection:Cell( "D2_COD"      ):SetValue( (cAliasTMP)->D2_COD     ) //--Cód.Produto
         oSection:Cell( "B1_DESC"     ):SetValue( Substr( (cAliasTMP)->B1_DESC,1,20 ) ) //--Descrição do Produto
         oSection:Cell( "B5_CEME"     ):SetValue( AllTrim( Posicione("SB5",1,xFilial("SB5")+(cAliasTMP)->D2_COD,"B5_CEME") ) ) //--Descrição Científico
         oSection:Cell( "B1_XDESCL1"  ):SetValue( AllTrim( (cAliasTMP)->B1_XDESCL1 ) ) //--Descrição Longa
-        oSection:Cell( "D2_UM"       ):SetValue( (cAliasTMP)->D2_UM ) //--Un Medida
-        oSection:Cell( "D2_QUANT"    ):SetValue( (cAliasTMP)->D2_QUANT ) //--Quant
-        oSection:Cell( "VlrFrete"    ):SetValue( nVlrFrete ) //--Frete
-        oSection:Cell( "VlrSeguro"   ):SetValue( nVlrSeguro ) //--Seguro
-        oSection:Cell( "VlrDesp"     ):SetValue( nVlrDesp ) //--Despesas
-        oSection:Cell( "D2_CUSTO1"   ):SetValue( (cAliasTMP)->D2_CUSTO1 ) //--Custo
-        oSection:Cell( "D2_CONTA"    ):SetValue( (cAliasTMP)->D2_CONTA ) //--Conta Contábil
+        oSection:Cell( "D2_UM"       ):SetValue( (cAliasTMP)->D2_UM      ) //--Un Medida
+        oSection:Cell( "D2_QUANT"    ):SetValue( (cAliasTMP)->D2_QUANT   ) //--Quant
+        oSection:Cell( "VlrFrete"    ):SetValue( nVlrFrete               ) //--Frete
+        oSection:Cell( "VlrSeguro"   ):SetValue( nVlrSeguro              ) //--Seguro
+        oSection:Cell( "VlrDesp"     ):SetValue( nVlrDesp                ) //--Despesas
+        oSection:Cell( "D2_CUSTO1"   ):SetValue( (cAliasTMP)->D2_CUSTO1  ) //--Custo
+        oSection:Cell( "D2_CONTA"    ):SetValue( (cAliasTMP)->D2_CONTA   ) //--Conta Contábil
         oSection:Cell( "CT1_DESC01"  ):SetValue( AllTrim( Posicione("CT1",1,xFilial("CT1")+(cAliasTMP)->D2_CONTA,"CT1_DESC01" ) ) ) //--Desc.Conta Contábil
         oSection:Cell( "D2_FILIAL"   ):SetValue( AllTrim( (cAliasTMP)->D2_FILIAL ) ) //--Empresa
-        oSection:Cell( "Situacao"    ):SetValue( cSituacao ) //--Situação
-        oSection:Cell( "TpNF"        ):SetValue( cTpNF ) //--Tipo Nota Fiscal
-        oSection:Cell( "FT_CHVNFE"   ):SetValue( (cAliasTMP)->FT_CHVNFE ) //--Chave Nota Fiscal
+        oSection:Cell( "Situacao"    ):SetValue( cSituacao               ) //--Situação
+        oSection:Cell( "TpNF"        ):SetValue( cTpNF                   ) //--Tipo Nota Fiscal
+        oSection:Cell( "FT_CHVNFE"   ):SetValue( (cAliasTMP)->FT_CHVNFE  ) //--Chave Nota Fiscal
         oSection:Cell( "D2_NFORI"    ):SetValue( AllTrim( (cAliasTMP)->D2_NFORI ) + " - " + AllTrim( (cAliasTMP)->D2_SERIORI ) ) //--Nota Fiscal Origem
-        oSection:Cell( "DescTipo"    ):SetValue( cDescTipo ) //--Tipo Cli\For
-        oSection:Cell( "TpCliFor"    ):SetValue( cTpCliFor ) //--Cli\For
-        oSection:Cell( "X5_DESCRI"   ):SetValue( AllTrim( Posicione("SX5" ,1 ,xFilial("SX5") + "12" + cEstCli,"X5_DESCRI") ) ) //--Estado
+        oSection:Cell( "DescTipo"    ):SetValue( cDescTipo               ) //--Tipo Cli\For
+        oSection:Cell( "TpCliFor"    ):SetValue( cTpCliFor               ) //--Cli\For
+        oSection:Cell( "X5_DESCRI"   ):SetValue( AllTrim( Posicione("SX5" ,1 ,xFilial("SX5") + "12" + cEstCli                                     ,"X5_DESCRI") ) ) //--Estado
         oSection:Cell( "CC2_MUN"     ):SetValue( AllTrim( Posicione("CC2" ,1 ,xFilial("CC2") + cEstCli + PadR( cCodMun ,TamSx3("CC2_CODMUN")[1] ) , "CC2_MUN" ) ) ) //--Município
         oSection:Cell( "B1_CEST"     ):SetValue( AllTrim( (cAliasTMP)->B1_CEST ) ) //--CEST
-        oSection:Cell( "DesMod"      ):SetValue( AllTrim( cDesMod ) ) //--Descr. Modelo Veículo
-        oSection:Cell( "ComVei"      ):SetValue( AllTrim( cComVei ) ) //--Combustível Veículo
+        oSection:Cell( "DesMod"      ):SetValue( AllTrim( cDesMod      ) ) //--Descr. Modelo Veículo
+        oSection:Cell( "ComVei"      ):SetValue( AllTrim( cComVei      ) ) //--Combustível Veículo
         oSection:Cell( "F4_TEXTO"    ):SetValue( AllTrim( (cAliasTMP)->F4_TEXTO ) ) //--Descrição CFOP
-        oSection:Cell( "F2_CODNFE"   ):SetValue( (cAliasTMP)->F2_CODNFE ) //--Cód.Verificação
+        oSection:Cell( "F2_CODNFE"   ):SetValue( (cAliasTMP)->F2_CODNFE  ) //--Cód.Verificação
         oSection:Cell( "FT_BASEIRR"  ):SetValue( (cAliasTMP)->FT_BASEIRR ) //--Base Irrf Retenção
         oSection:Cell( "FT_ALIQIRR"  ):SetValue( (cAliasTMP)->FT_ALIQIRR ) //--Aliq. Irrf Retenção
-        oSection:Cell( "FT_VALIRR"   ):SetValue( (cAliasTMP)->FT_VALIRR ) //--Irrf Retenção
+        oSection:Cell( "FT_VALIRR"   ):SetValue( (cAliasTMP)->FT_VALIRR  ) //--Irrf Retenção
         oSection:Cell( "FT_BASEINS"  ):SetValue( (cAliasTMP)->FT_BASEINS ) //--Base Inss
         oSection:Cell( "FT_ALIQINS"  ):SetValue( (cAliasTMP)->FT_ALIQINS ) //--Aliq. Inss
         oSection:Cell( "D2_ABATINS"  ):SetValue( (cAliasTMP)->D2_ABATINS ) //--Inss Recolhido
-        oSection:Cell( "FT_VALINS"   ):SetValue( (cAliasTMP)->FT_VALINS ) //--Valor Inss
+        oSection:Cell( "FT_VALINS"   ):SetValue( (cAliasTMP)->FT_VALINS  ) //--Valor Inss
         oSection:Cell( "D2_BASEISS"  ):SetValue( (cAliasTMP)->D2_BASEISS ) //--Base Iss
         oSection:Cell( "D2_ALIQISS"  ):SetValue( (cAliasTMP)->D2_ALIQISS ) //--Aliq. Iss
         oSection:Cell( "D2_ABATISS"  ):SetValue( (cAliasTMP)->D2_ABATISS ) //--Iss Serviços
         oSection:Cell( "D2_ABATMAT"  ):SetValue( (cAliasTMP)->D2_ABATMAT ) //--Iss Materiais
-        oSection:Cell( "D2_VALISS"   ):SetValue( (cAliasTMP)->D2_VALISS ) //--Valor Iss
+        oSection:Cell( "D2_VALISS"   ):SetValue( (cAliasTMP)->D2_VALISS  ) //--Valor Iss
         oSection:Cell( "FT_BASECSL"  ):SetValue( (cAliasTMP)->FT_BASECSL ) //--Base Csll
         oSection:Cell( "FT_ALIQCSL"  ):SetValue( IIF( (cAliasTMP)->FT_BASECSL > 0, (cAliasTMP)->FT_ALIQCSL, 0 ) ) //--Aliq. Csll
-        oSection:Cell( "FT_VALCSL"   ):SetValue( (cAliasTMP)->FT_VALCSL ) //--Valor Csll
+        oSection:Cell( "FT_VALCSL"   ):SetValue( (cAliasTMP)->FT_VALCSL  ) //--Valor Csll
         oSection:Cell( "FT_BRETPIS"  ):SetValue( (cAliasTMP)->FT_BRETPIS ) //--Base Pis Retenção
         oSection:Cell( "FT_ARETPIS"  ):SetValue( IIF( (cAliasTMP)->FT_BRETPIS > 0, (cAliasTMP)->FT_ARETPIS, 0 ) ) //--Aliq. Pis Retenção
         oSection:Cell( "FT_VRETPIS"  ):SetValue( (cAliasTMP)->FT_VRETPIS ) //--Valor Pis Retenção
         oSection:Cell( "FT_BRETCOF"  ):SetValue( (cAliasTMP)->FT_BRETCOF ) //--Base Cofins Retenção
         oSection:Cell( "FT_ARETCOF"  ):SetValue( IIF( (cAliasTMP)->FT_BRETCOF > 0, (cAliasTMP)->FT_ARETCOF, 0 ) ) //--Aliq. Cofins Retenção
-        oSection:Cell( "FT_VRETCOF"   ):SetValue( (cAliasTMP)->FT_VRETCOF ) //--Valor Cofins Retenção
-        oSection:Cell( "LogInc"      ):SetValue( cLogInc ) //--Log. de Inclusão
-        oSection:Cell( "LogAlt"      ):SetValue( cLogAlt ) //--Log. de Alteração
-        oSection:Cell( "DtLogAlt"    ):SetValue( cDtLogAlt ) //--Dt. Log. de Alteração
+        oSection:Cell( "FT_VRETCOF"  ):SetValue( (cAliasTMP)->FT_VRETCOF ) //--Valor Cofins Retenção
+        oSection:Cell( "LogInc"      ):SetValue( cLogInc                 ) //--Log. de Inclusão
+        oSection:Cell( "LogAlt"      ):SetValue( cLogAlt                 ) //--Log. de Alteração
+        oSection:Cell( "DtLogAlt"    ):SetValue( cDtLogAlt               ) //--Dt. Log. de Alteração
         oSection:Cell( "VV3_TIPVEN"  ):SetValue( AllTrim( (cAliasTMP)->VV3_TIPVEN ) ) //--Tipo Venda
         oSection:Cell( "VV3_DESCRI"  ):SetValue( AllTrim( (cAliasTMP)->VV3_DESCRI ) ) //--Descr. Tipo Venda
-        oSection:Cell( "NumPed"      ):SetValue( cNumPed ) //--Num. Pedido
-        oSection:Cell( "Naturez"     ):SetValue( cNaturez ) //--Natureza Financeira
+        oSection:Cell( "NumPed"      ):SetValue( cNumPed                 ) //--Num. Pedido
+        oSection:Cell( "Naturez"     ):SetValue( cNaturez                ) //--Natureza Financeira
         oSection:Cell( "C6_TNATREC"  ):SetValue( AllTrim( (cAliasTMP)->C6_TNATREC ) ) //--Tab. Nat. Receita
         oSection:Cell( "D2_ITEMCC"   ):SetValue( AllTrim( (cAliasTMP)->D2_ITEMCC ) ) //--Item Contábil
         oSection:Cell( "F3_ISENICM"  ):SetValue( (cAliasTMP)->F3_ISENICM ) //--ICMS Isento
         oSection:Cell( "F3_OUTRICM"  ):SetValue( (cAliasTMP)->F3_OUTRICM ) //--ICMS Outros
         oSection:Cell( "F3_ISENIPI"  ):SetValue( (cAliasTMP)->F3_ISENIPI ) //--IPI Isento
         oSection:Cell( "F3_OUTRIPI"  ):SetValue( (cAliasTMP)->F3_OUTRIPI ) //--IPI Outros
-        oSection:Cell( "Transp"      ):SetValue( cTransp ) //--Cód. Transportadora
+        oSection:Cell( "Transp"      ):SetValue( cTransp                 ) //--Cód. Transportadora
         oSection:Cell( "VRJ_CLIRET"  ):SetValue( (cAliasTMP)->VRJ_CLIRET ) //--Cat. Local de Entrega
-        oSection:Cell( "NomLocEnt"   ):SetValue( cNomLocEnt ) //--Nome Loc. Entr.
-        oSection:Cell( "UFLocEnt"    ):SetValue( cUFLocEnt ) //--UF Loc. Entr.
+        oSection:Cell( "NomLocEnt"   ):SetValue( cNomLocEnt              ) //--Nome Loc. Entr.
+        oSection:Cell( "UFLocEnt"    ):SetValue( cUFLocEnt               ) //--UF Loc. Entr.
         oSection:Cell( "F2_MENNOTA"  ):SetValue( (cAliasTMP)->F2_MENNOTA ) //--Msgn Nota Fiscal   
-        oSection:Cell( "MenNota"     ):SetValue( cMenNota ) //--Mens.p/Nota
-        oSection:Cell( "MenPad"      ):SetValue( cMenPad ) //--Mens. Padrão
-        oSection:Cell( "MensNFS"     ):SetValue( cMensNFS ) //--Mensagem NFS	
+        oSection:Cell( "MenNota"     ):SetValue( cMenNota                ) //--Mens.p/Nota
+        oSection:Cell( "MenPad"      ):SetValue( cMenPad                 ) //--Mens. Padrão
+        oSection:Cell( "MensNFS"     ):SetValue( cMensNFS                ) //--Mensagem NFS	
         oSection:Cell( "VlrTrib"     ):SetValue( (cAliasTMP)->( F2_TOTFED + F2_TOTEST ) ) //--Vlr. Aprox. dos Tributos	
         oSection:Cell( "F4_DUPLIC"   ):SetValue( Alltrim( (cAliasTMP)->F4_DUPLIC ) ) //--Gera Duplicata   
 
@@ -563,144 +572,144 @@ Static Function zTmpRadio3()
 		(cAliasTMP)->(DbCloseArea())
 	EndIf
 
-    cQuery += " SELECT D2_FILIAL, D2_COD, D2_DOC,D2_SERIE, D2_TES, D2_CF,D2_CLIENTE,D2_LOJA,D2_EMISSAO, D2_ITEMPV, "		+ CRLF
-	cQuery += " F4_FINALID, F4_TEXTO, FT_CTIPI, FT_CSTPIS, FT_CSTCOF, F4_ICM, F4_IPI, F4_CREDICM, F4_CREDIPI, F4_DUPLIC, "	+ CRLF
-	cQuery += " B1_DESC, B1_XDESCL1, B1_GRUPO, B1_POSIPI, B1_CEST, B1_ORIGEM, B1_EX_NCM, B1_EX_NBM, D2_ITEM, "							+ CRLF
-	cQuery += " F2_ESPECIE,F2_CODNFE,F2_MENNOTA,F2_USERLGI,F2_USERLGA,F2_TIPO, FT_CHVNFE,F2_DOC, F2_SERIE, F2_FIMP,  " 		+ CRLF
-	cQuery += " FT_VALCONT, F2_FORMUL, D2_CONTA, D2_NFORI, D2_SERIORI, D2_PRUNIT,D2_TOTAL, "								+ CRLF
-	cQuery += " D2_DESPESA, D2_SEGURO, D2_VALFRE, D2_DESCON, "	                                                            + CRLF
-    cQuery += " FT_CLASFIS, D2_DESCZFP, D2_DESCZFC, D2_TIPO, "														        + CRLF
-	cQuery += " FT_BASEICM, FT_ALIQICM, FT_VALICM, C6_CHASSI, "																+ CRLF
-	cQuery += " FT_BASEIPI, FT_ALIQIPI, FT_VALIPI, FT_BRETPIS, FT_ARETPIS, FT_VRETPIS, FT_BRETCOF, FT_ARETCOF, FT_VRETCOF, "+ CRLF
-	cQuery += " FT_BASERET, FT_ICMSRET, FT_DIFAL, "																			+ CRLF
-	cQuery += " D2_BASIMP6,D2_ALQIMP6,D2_VALIMP6,   " 																		+ CRLF
-	cQuery += " D2_BASIMP5,D2_ALQIMP5,D2_VALIMP5, " 											                            + CRLF
-	cQuery += " FT_BASEPIS,FT_ALIQPIS,FT_VALPIS, F2_TOTFED, F2_TOTEST, "													+ CRLF
-	cQuery += " FT_BASECOF,FT_ALIQCOF,FT_VALCOF, FT_BASECF3, FT_ALIQCF3, FT_VALCF3, FT_BASEPS3, FT_ALIQPS3, FT_VALPS3, "	+ CRLF
-	cQuery += " FT_BASEIRR,FT_ALIQIRR,FT_VALIRR, F3_OUTRIPI, F3_ISENIPI, F3_OUTRICM, F3_ISENICM,  "							+ CRLF
-	cQuery += " FT_BASEINS,FT_ALIQINS,D2_ABATINS,FT_VALINS, D2_UM, D2_QUANT, "												+ CRLF
-	cQuery += " D2_BASEISS,D2_ALIQISS,D2_ABATISS,D2_ABATMAT,D2_VALISS, D2_ITEMCC, "											+ CRLF
-	cQuery += " FT_BASECSL,FT_ALIQCSL,FT_VALCSL, D2_CUSTO1, VRK_CHASSI, VRJ_CODCLI, VRJ_LOJA, C6_XVLCOM, "					+ CRLF
-	cQuery += " C6_TNATREC, C6_NFORI, C6_FILIAL, C6_NUM, VV3_TIPVEN, VV3_DESCRI, VRJ_CLIRET, VRK_OPCION "		            + CRLF
-	cQuery += " FROM   " + RetSQLName("SD2") + " SD2   " 																	+ CRLF
-	
-	cQuery += "	INNER JOIN " + RetSQLName("SF2") + " SF2 "																    + CRLF
-	cQuery += "		ON SF2.F2_FILIAL = '" + FWxFilial('SF2') + "' "													        + CRLF
-	cQuery += "		AND SD2.D2_DOC = SF2.F2_DOC   " 																	    + CRLF
-	cQuery += "		AND SD2.D2_SERIE = SF2.F2_SERIE   " 																    + CRLF
-	cQuery += "		AND SD2.D2_CLIENTE = SF2.F2_CLIENTE   " 															    + CRLF
-	cQuery += "		AND SD2.D2_LOJA = SF2.F2_LOJA   " 																	    + CRLF
-	cQuery += "		AND SD2.D2_EMISSAO = SF2.F2_EMISSAO   " 															    + CRLF
-	cQuery += "		AND SF2.F2_ESPECIE BETWEEN '" + MV_PAR03 + "' AND '" + MV_PAR04 + "' " 								    + CRLF
-	cQuery += "		AND SF2.D_E_L_E_T_ = ' '   "	 																	    + CRLF
+    cQuery += CRLF + " SELECT D2_FILIAL , D2_COD    , D2_DOC    , D2_SERIE  , D2_TES    , D2_CF    , D2_CLIENTE, D2_LOJA    , D2_EMISSAO , D2_ITEMPV, "
+	cQuery += CRLF + "        F4_FINALID, F4_TEXTO  , FT_CTIPI  , FT_CSTPIS , FT_CSTCOF , F4_ICM   , F4_IPI    , F4_CREDICM , F4_CREDIPI , F4_DUPLIC, "
+	cQuery += CRLF + "        B1_DESC   , B1_XDESCL1, B1_GRUPO  , B1_POSIPI , B1_CEST   , B1_ORIGEM, B1_EX_NCM , B1_EX_NBM  , D2_ITEM    , "
+	cQuery += CRLF + "        F2_ESPECIE, F2_CODNFE , F2_MENNOTA, F2_USERLGI,F2_USERLGA , F2_TIPO  , FT_CHVNFE , F2_DOC     , F2_SERIE   , F2_FIMP,  "
+	cQuery += CRLF + "        FT_VALCONT, F2_FORMUL , D2_CONTA  , D2_NFORI  , D2_SERIORI, D2_PRUNIT, D2_TOTAL  , "
+	cQuery += CRLF + "        D2_DESPESA, D2_SEGURO , D2_VALFRE , D2_DESCON , "
+    cQuery += CRLF + "        FT_CLASFIS, D2_DESCZFP, D2_DESCZFC, D2_TIPO   , "
+	cQuery += CRLF + "        FT_BASEICM, FT_ALIQICM, FT_VALICM , C6_CHASSI , "
+	cQuery += CRLF + "        FT_BASEIPI, FT_ALIQIPI, FT_VALIPI , FT_BRETPIS, FT_ARETPIS, FT_VRETPIS, FT_BRETCOF, FT_ARETCOF, FT_VRETCOF, "
+	cQuery += CRLF + "        FT_BASERET, FT_ICMSRET, FT_DIFAL  , "
+	cQuery += CRLF + "        D2_BASIMP6, D2_ALQIMP6, D2_VALIMP6, "
+	cQuery += CRLF + "        D2_BASIMP5, D2_ALQIMP5, D2_VALIMP5, "
+	cQuery += CRLF + "        FT_BASEPIS, FT_ALIQPIS, FT_VALPIS , F2_TOTFED , F2_TOTEST, "
+	cQuery += CRLF + "        FT_BASECOF, FT_ALIQCOF, FT_VALCOF , FT_BASECF3, FT_ALIQCF3, FT_VALCF3 , FT_BASEPS3, FT_ALIQPS3, FT_VALPS3, "
+	cQuery += CRLF + "        FT_BASEIRR, FT_ALIQIRR, FT_VALIRR , F3_OUTRIPI, F3_ISENIPI, F3_OUTRICM, F3_ISENICM, "
+	cQuery += CRLF + "        FT_BASEINS, FT_ALIQINS, D2_ABATINS, FT_VALINS , D2_UM     , D2_QUANT  , "
+	cQuery += CRLF + "        D2_BASEISS, D2_ALIQISS, D2_ABATISS, D2_ABATMAT, D2_VALISS , D2_ITEMCC , "
+	cQuery += CRLF + "        FT_BASECSL, FT_ALIQCSL, FT_VALCSL , D2_CUSTO1 , VRK_CHASSI, VRJ_CODCLI, VRJ_LOJA  , C6_XVLCOM, "
+	cQuery += CRLF + "        C6_TNATREC, C6_NFORI, C6_FILIAL   , C6_NUM    , VV3_TIPVEN, VV3_DESCRI, VRJ_CLIRET, VRK_OPCION, D2_DESCZFR, D2_VRDICMS "
+	cQuery += CRLF + " FROM   " + RetSQLName("SD2") + " SD2   "
+
+	cQuery += CRLF + "	INNER JOIN " + RetSQLName("SF2") + " SF2 "
+	cQuery += CRLF + "		ON SF2.F2_FILIAL   = '" + FWxFilial('SF2') + "' "
+	cQuery += CRLF + "		AND SD2.D2_DOC     = SF2.F2_DOC "
+	cQuery += CRLF + "		AND SD2.D2_SERIE   = SF2.F2_SERIE "
+	cQuery += CRLF + "		AND SD2.D2_CLIENTE = SF2.F2_CLIENTE "
+	cQuery += CRLF + "		AND SD2.D2_LOJA    = SF2.F2_LOJA  "
+	cQuery += CRLF + "		AND SD2.D2_EMISSAO = SF2.F2_EMISSAO "
+	cQuery += CRLF + "		AND SF2.F2_ESPECIE BETWEEN '" + MV_PAR03 + "' AND '" + MV_PAR04 + "' "
+	cQuery += CRLF + "		AND SF2.D_E_L_E_T_ = ' ' "
 
 	If !Empty( MV_PAR17 )
-		cQuery += " 	AND SF2.F2_EST = '" + MV_PAR17 + "' " 															    + CRLF
+		cQuery += CRLF + " 	AND SF2.F2_EST = '" + MV_PAR17 + "' "
 	EndIf
 	
-	cQuery += " INNER JOIN " + RetSQLName("SB1") + " SB1 " 												 				    + CRLF
-	cQuery += "		ON SB1.B1_FILIAL = '" + FWxFilial('SB1') + "' "													        + CRLF
-	cQuery += "		AND SB1.B1_COD = SD2.D2_COD   "	 																	    + CRLF
-	cQuery += "		AND SB1.D_E_L_E_T_ = ' ' " 																			    + CRLF
+	cQuery += CRLF + " INNER JOIN " + RetSQLName("SB1") + " SB1 "
+	cQuery += CRLF + "		ON  SB1.B1_FILIAL  = '" + FWxFilial('SB1') + "' "
+	cQuery += CRLF + "		AND SB1.B1_COD     = SD2.D2_COD "
+	cQuery += CRLF + "		AND SB1.D_E_L_E_T_ = ' ' "
 
 	If !Empty( MV_PAR18 )
-		cQuery += " 	AND SB1.B1_GRUPO = '" + MV_PAR18 + "' "															    + CRLF
+		cQuery += CRLF + " 	AND SB1.B1_GRUPO = '" + MV_PAR18 + "' "
 	EndIf
 
 	If !Empty( MV_PAR19 )
-		cQuery += " 	AND SB1.B1_POSIPI = '" + MV_PAR19 + "' "														    + CRLF
+		cQuery += CRLF + " 	AND SB1.B1_POSIPI = '" + MV_PAR19 + "' "
 	EndIf
 
-	cQuery += " INNER JOIN " + RetSQLName("SF4") + " SF4 "																    + CRLF
-	cQuery += "		ON SF4.F4_FILIAL = '" + FWxFilial('SF4') + "'  "												        + CRLF
-	cQuery += "		AND SF4.F4_CODIGO = SD2.D2_TES  "	 																    + CRLF
-	cQuery += "     AND SF4.D_E_L_E_T_ = ' '   " 																		    + CRLF
+	cQuery += CRLF + " INNER JOIN " + RetSQLName("SF4") + " SF4 "
+	cQuery += CRLF + "		ON  SF4.F4_FILIAL  = '" + FWxFilial('SF4') + "' "
+	cQuery += CRLF + "		AND SF4.F4_CODIGO  = SD2.D2_TES "
+	cQuery += CRLF + "      AND SF4.D_E_L_E_T_ = ' '  "
 	
-	cQuery += " LEFT JOIN " + RetSQLName("SC6") + " SC6 "																    + CRLF
-	cQuery += "		ON SC6.C6_FILIAL = '" + FWxFilial('SC6') + "' "													        + CRLF
-	cQuery += "		AND SC6.C6_NUM = SD2.D2_PEDIDO  "																	    + CRLF
-	cQuery += "		AND SC6.C6_ITEM = SD2.D2_ITEMPV  "		 															    + CRLF
-	cQuery += "		AND SC6.C6_PRODUTO = SD2.D2_COD "		 															    + CRLF
-	cQuery += "     AND SC6.D_E_L_E_T_ = ' '   " 																		    + CRLF
+	cQuery += CRLF + " LEFT JOIN " + RetSQLName("SC6") + " SC6 "
+	cQuery += CRLF + "		ON  SC6.C6_FILIAL  = '" + FWxFilial('SC6') + "' "
+	cQuery += CRLF + "		AND SC6.C6_NUM     = SD2.D2_PEDIDO  "
+	cQuery += CRLF + "		AND SC6.C6_ITEM    = SD2.D2_ITEMPV  "
+	cQuery += CRLF + "		AND SC6.C6_PRODUTO = SD2.D2_COD "
+	cQuery += CRLF + "      AND SC6.D_E_L_E_T_ = ' '   "
 	
-	cQuery += " LEFT JOIN " + RetSQLName("VV0") + " VV0 "																    + CRLF
-	cQuery += "		ON VV0.VV0_FILIAL = '" + FWxFilial('VV0') + "' "												        + CRLF
-	cQuery += "		AND VV0.VV0_NUMNFI = SF2.F2_DOC  "	 																    + CRLF
-	cQuery += "		AND VV0.VV0_SERNFI = SF2.F2_SERIE  "																    + CRLF
-	cQuery += "     AND VV0.D_E_L_E_T_ = ' '   " 																		    + CRLF
+	cQuery += CRLF + " LEFT JOIN " + RetSQLName("VV0") + " VV0 "
+	cQuery += CRLF + "		ON  VV0.VV0_FILIAL = '" + FWxFilial('VV0') + "' "
+	cQuery += CRLF + "		AND VV0.VV0_NUMNFI = SF2.F2_DOC  "
+	cQuery += CRLF + "		AND VV0.VV0_SERNFI = SF2.F2_SERIE  "
+	cQuery += CRLF + "      AND VV0.D_E_L_E_T_ = ' ' "
 	
-	cQuery += " LEFT JOIN " + RetSQLName("VV3") + " VV3 "																    + CRLF
-	cQuery += "		ON VV3.VV3_FILIAL = '" + FWxFilial('VV3') + "' " 												        + CRLF
-	cQuery += " 	AND VV3.VV3_TIPVEN = VV0.VV0_TIPVEN  "			 													    + CRLF
-	cQuery += "     AND VV3.D_E_L_E_T_ = ' '   " 																		    + CRLF
+	cQuery += CRLF + " LEFT JOIN " + RetSQLName("VV3") + " VV3 "
+	cQuery += CRLF + "		ON  VV3.VV3_FILIAL = '" + FWxFilial('VV3') + "' "
+	cQuery += CRLF + " 	    AND VV3.VV3_TIPVEN = VV0.VV0_TIPVEN  "
+	cQuery += CRLF + "      AND VV3.D_E_L_E_T_ = ' '   "
 
-	cQuery += " LEFT JOIN " + RetSQLName("VRK") + " VRK "																    + CRLF
-	cQuery += " 	ON VRK.VRK_FILIAL = '" + FWxFilial('VRK') + "' "  												        + CRLF
-	cQuery += " 	AND VRK.VRK_NUMTRA = VV0.VV0_NUMTRA  "			 													    + CRLF
-	cQuery += "     AND VRK.D_E_L_E_T_ = ' '   " 																		    + CRLF
+	cQuery += CRLF + " LEFT JOIN " + RetSQLName("VRK") + " VRK "
+	cQuery += CRLF + " 	    ON  VRK.VRK_FILIAL = '" + FWxFilial('VRK') + "' "
+	cQuery += CRLF + " 	    AND VRK.VRK_NUMTRA = VV0.VV0_NUMTRA  "
+	cQuery += CRLF + "      AND VRK.D_E_L_E_T_ = ' '   "
 
-	cQuery += " LEFT JOIN " + RetSQLName("VRJ") + " VRJ "																    + CRLF
-	cQuery += " 	ON VRJ.VRJ_FILIAL = '" + FWxFilial('VRJ') + "' "  												        + CRLF
-	cQuery += " 	AND VRJ.VRJ_PEDIDO = VRK.VRK_PEDIDO  "			 													    + CRLF
-	cQuery += "     AND VRJ.D_E_L_E_T_ = ' '   " 																		    + CRLF
+	cQuery += CRLF + " LEFT JOIN " + RetSQLName("VRJ") + " VRJ "
+	cQuery += CRLF + " 	    ON  VRJ.VRJ_FILIAL = '" + FWxFilial('VRJ') + "' "
+	cQuery += CRLF + " 	    AND VRJ.VRJ_PEDIDO = VRK.VRK_PEDIDO  "
+	cQuery += CRLF + "      AND VRJ.D_E_L_E_T_ = ' '   "
 
-	cQuery += " INNER JOIN " + RetSQLName("SFT") + " SFT " 																    + CRLF
-	cQuery += "		ON SFT.FT_FILIAL = '" + FWxFilial('SFT') + "' "													        + CRLF
-	cQuery += "		AND SFT.FT_TIPOMOV = 'S' "																			    + CRLF
-	cQuery += "		AND SFT.FT_SERIE = SD2.D2_SERIE "																	    + CRLF
-	cQuery += " 	AND SFT.FT_NFISCAL = SD2.D2_DOC "																	    + CRLF
-	cQuery += "		AND SFT.FT_CLIEFOR = SD2.D2_CLIENTE " 																    + CRLF
-	cQuery += "		AND SFT.FT_LOJA = SD2.D2_LOJA " 																	    + CRLF
-	cQuery += "		AND SFT.FT_ITEM = SD2.D2_ITEM " 																	    + CRLF
-	cQuery += "		AND SFT.FT_PRODUTO = SD2.D2_COD " 																	    + CRLF	
-	cQuery += "		AND SFT.D_E_L_E_T_ = ' ' "																			    + CRLF
+	cQuery += CRLF + " INNER JOIN " + RetSQLName("SFT") + " SFT "
+	cQuery += CRLF + "		ON  SFT.FT_FILIAL  = '" + FWxFilial('SFT') + "' "
+	cQuery += CRLF + "		AND SFT.FT_TIPOMOV = 'S' "
+	cQuery += CRLF + "		AND SFT.FT_SERIE   = SD2.D2_SERIE "
+	cQuery += CRLF + " 	    AND SFT.FT_NFISCAL = SD2.D2_DOC "
+	cQuery += CRLF + "		AND SFT.FT_CLIEFOR = SD2.D2_CLIENTE "
+	cQuery += CRLF + "		AND SFT.FT_LOJA    = SD2.D2_LOJA "
+	cQuery += CRLF + "		AND SFT.FT_ITEM    = SD2.D2_ITEM "
+	cQuery += CRLF + "		AND SFT.FT_PRODUTO = SD2.D2_COD "
+	cQuery += CRLF + "		AND SFT.D_E_L_E_T_ = ' ' "
 
-	cQuery += " INNER JOIN " + RetSQLName("SF3") + " SF3 " 																    + CRLF
-	cQuery += "		ON SF3.F3_FILIAL = '" + FWxFilial('SF3') + "' "	 												        + CRLF
-	cQuery += "		AND SF3.F3_SERIE = SFT.FT_SERIE "																	    + CRLF
-	cQuery += "		AND SF3.F3_NFISCAL = SFT.FT_NFISCAL "																    + CRLF
-	cQuery += " 	AND SF3.F3_CLIEFOR = SFT.FT_CLIEFOR "																    + CRLF
-	cQuery += "		AND SF3.F3_LOJA = SFT.FT_LOJA " 																	    + CRLF
-	cQuery += "		AND SF3.F3_IDENTFT = SFT.FT_IDENTF3 " 																    + CRLF
-	cQuery += "		AND SF3.D_E_L_E_T_ = ' ' "																			    + CRLF
+	cQuery += CRLF + " INNER JOIN " + RetSQLName("SF3") + " SF3 "
+	cQuery += CRLF + "		ON SF3.F3_FILIAL   = '" + FWxFilial('SF3') + "' "
+	cQuery += CRLF + "		AND SF3.F3_SERIE   = SFT.FT_SERIE "
+	cQuery += CRLF + "		AND SF3.F3_NFISCAL = SFT.FT_NFISCAL "
+	cQuery += CRLF + " 	    AND SF3.F3_CLIEFOR = SFT.FT_CLIEFOR "
+	cQuery += CRLF + "		AND SF3.F3_LOJA    = SFT.FT_LOJA "
+	cQuery += CRLF + "		AND SF3.F3_IDENTFT = SFT.FT_IDENTF3 "
+	cQuery += CRLF + "		AND SF3.D_E_L_E_T_ = ' ' "
 
-	cQuery += " WHERE  SD2.D2_FILIAL BETWEEN '" + MV_PAR01 + "' AND '" + MV_PAR02 + "' "								    + CRLF
-	cQuery += " 	AND SD2.D2_DOC BETWEEN '" + MV_PAR05 + "' AND '" + MV_PAR06 + "' " 									    + CRLF
-	cQuery += " 	AND SD2.D2_SERIE BETWEEN '" + MV_PAR07 + "' AND '" + MV_PAR08 + "' " 								    + CRLF
-	cQuery += " 	AND SD2.D2_CLIENTE BETWEEN '" + MV_PAR09 + "' AND '" + MV_PAR10 + "' " 								    + CRLF
-	cQuery += " 	AND SD2.D2_EMISSAO BETWEEN '" + DToS(MV_PAR11) + "' AND '" + DToS(MV_PAR12) + "' " 					    + CRLF
-	cQuery += " 	AND SD2.D2_COD BETWEEN '" + MV_PAR13 + "' AND '" + MV_PAR14 + "' " 									    + CRLF
-	cQuery += " 	AND SD2.D_E_L_E_T_ = ' ' " 																			    + CRLF
+	cQuery += CRLF + " WHERE    SD2.D2_FILIAL  BETWEEN '" + MV_PAR01 + "' AND '" + MV_PAR02 + "' "
+	cQuery += CRLF + " 	    AND SD2.D2_DOC     BETWEEN '" + MV_PAR05 + "' AND '" + MV_PAR06 + "' "
+	cQuery += CRLF + " 	    AND SD2.D2_SERIE   BETWEEN '" + MV_PAR07 + "' AND '" + MV_PAR08 + "' "
+	cQuery += CRLF + " 	    AND SD2.D2_CLIENTE BETWEEN '" + MV_PAR09 + "' AND '" + MV_PAR10 + "' "
+	cQuery += CRLF + " 	    AND SD2.D2_EMISSAO BETWEEN '" + DToS(MV_PAR11) + "' AND '" + DToS(MV_PAR12) + "' "
+	cQuery += CRLF + " 	    AND SD2.D2_COD     BETWEEN '" + MV_PAR13 + "' AND '" + MV_PAR14 + "' "
+	cQuery += CRLF + " 	    AND SD2.D_E_L_E_T_ = ' ' "
 
 	If !Empty( MV_PAR15 )
-		cQuery += " 	AND SD2.D2_TES = '" + MV_PAR15 + "' " 															    + CRLF
+		cQuery += CRLF + " 	AND SD2.D2_TES = '" + MV_PAR15 + "' "
 	EndIf
 
 	If !Empty( MV_PAR16 )
-		cQuery += " 	AND SD2.D2_CF = '" + MV_PAR16 + "' " 															    + CRLF
+		cQuery += CRLF + " 	AND SD2.D2_CF = '" + MV_PAR16 + "' "
 	EndIf  
 
-	cQuery += " GROUP BY D2_FILIAL, D2_COD, D2_DOC,D2_SERIE, D2_TES, D2_CF,D2_CLIENTE,D2_LOJA,D2_EMISSAO, D2_ITEMPV, "		+ CRLF
-	cQuery += " F4_FINALID, F4_TEXTO, FT_CTIPI, FT_CSTPIS, FT_CSTCOF, F4_ICM, F4_IPI, F4_CREDICM, F4_CREDIPI, F4_DUPLIC, "	+ CRLF
-	cQuery += " B1_DESC, B1_XDESCL1, B1_GRUPO, B1_POSIPI, B1_CEST, B1_ORIGEM, B1_EX_NCM, B1_EX_NBM, D2_ITEM, "							+ CRLF
-	cQuery += " F2_ESPECIE,F2_CODNFE,F2_MENNOTA,F2_USERLGI,F2_USERLGA,F2_TIPO, FT_CHVNFE,F2_DOC, F2_SERIE, F2_FIMP,  " 		+ CRLF
-	cQuery += " FT_VALCONT, F2_FORMUL, D2_CONTA, D2_NFORI, D2_SERIORI, D2_PRUNIT,D2_TOTAL, "								+ CRLF
-	cQuery += " D2_DESPESA, D2_SEGURO, D2_VALFRE, D2_DESCON, "	                                                            + CRLF
-    cQuery += " FT_CLASFIS, D2_DESCZFP, D2_DESCZFC, D2_TIPO, "														        + CRLF
-	cQuery += " FT_BASEICM, FT_ALIQICM, FT_VALICM, C6_CHASSI, "																+ CRLF
-	cQuery += " FT_BASEIPI, FT_ALIQIPI, FT_VALIPI, FT_BRETPIS, FT_ARETPIS, FT_VRETPIS, FT_BRETCOF, FT_ARETCOF, FT_VRETCOF, "+ CRLF
-	cQuery += " FT_BASERET, FT_ICMSRET, FT_DIFAL, "																			+ CRLF
-	cQuery += " D2_BASIMP6,D2_ALQIMP6,D2_VALIMP6,   " 																		+ CRLF
-	cQuery += " D2_BASIMP5,D2_ALQIMP5,D2_VALIMP5,   " 																		+ CRLF
-	cQuery += " FT_BASEPIS,FT_ALIQPIS,FT_VALPIS, F2_TOTFED, F2_TOTEST, " 													+ CRLF
-	cQuery += " FT_BASECOF,FT_ALIQCOF,FT_VALCOF, FT_BASECF3, FT_ALIQCF3, FT_VALCF3, FT_BASEPS3, FT_ALIQPS3, FT_VALPS3, "	+ CRLF
-	cQuery += " FT_BASEIRR,FT_ALIQIRR,FT_VALIRR, F3_OUTRIPI, F3_ISENIPI, F3_OUTRICM, F3_ISENICM,  "							+ CRLF
-	cQuery += " FT_BASEINS,FT_ALIQINS,D2_ABATINS,FT_VALINS, D2_UM, D2_QUANT, "												+ CRLF
-	cQuery += " D2_BASEISS,D2_ALIQISS,D2_ABATISS,D2_ABATMAT,D2_VALISS, D2_ITEMCC, "											+ CRLF
-	cQuery += " FT_BASECSL,FT_ALIQCSL,FT_VALCSL, D2_CUSTO1, VRK_CHASSI, VRJ_CODCLI, VRJ_LOJA, C6_XVLCOM,  "					+ CRLF
-	cQuery += " C6_TNATREC, C6_NFORI, C6_FILIAL, C6_NUM, VV3_TIPVEN, VV3_DESCRI, VRJ_CLIRET, VRK_OPCION, F2_VALBRUT "		+ CRLF
+	cQuery += CRLF + " GROUP BY D2_FILIAL , D2_COD    , D2_DOC    , D2_SERIE  , D2_TES    , D2_CF    , D2_CLIENTE, D2_LOJA   , D2_EMISSAO, D2_ITEMPV, "
+	cQuery += CRLF + "          F4_FINALID, F4_TEXTO  , FT_CTIPI  , FT_CSTPIS , FT_CSTCOF , F4_ICM   , F4_IPI    , F4_CREDICM, F4_CREDIPI, F4_DUPLIC, "
+	cQuery += CRLF + "          B1_DESC   , B1_XDESCL1, B1_GRUPO  , B1_POSIPI , B1_CEST   , B1_ORIGEM, B1_EX_NCM , B1_EX_NBM , D2_ITEM   , "
+	cQuery += CRLF + "          F2_ESPECIE, F2_CODNFE , F2_MENNOTA, F2_USERLGI, F2_USERLGA, F2_TIPO  , FT_CHVNFE , F2_DOC    , F2_SERIE  , F2_FIMP,  "
+	cQuery += CRLF + "          FT_VALCONT, F2_FORMUL , D2_CONTA  , D2_NFORI  , D2_SERIORI, D2_PRUNIT, D2_TOTAL  , "
+	cQuery += CRLF + "          D2_DESPESA, D2_SEGURO , D2_VALFRE , D2_DESCON ,"
+    cQuery += CRLF + "          FT_CLASFIS, D2_DESCZFP, D2_DESCZFC, D2_TIPO   ,"
+	cQuery += CRLF + "          FT_BASEICM, FT_ALIQICM, FT_VALICM , C6_CHASSI ,"
+	cQuery += CRLF + "          FT_BASEIPI, FT_ALIQIPI, FT_VALIPI , FT_BRETPIS, FT_ARETPIS, FT_VRETPIS, FT_BRETCOF, FT_ARETCOF, FT_VRETCOF, "
+	cQuery += CRLF + "          FT_BASERET, FT_ICMSRET, FT_DIFAL  , " 
+ 	cQuery += CRLF + "          D2_BASIMP6, D2_ALQIMP6, D2_VALIMP6, " 
+ 	cQuery += CRLF + "          D2_BASIMP5, D2_ALQIMP5, D2_VALIMP5, " 
+ 	cQuery += CRLF + "          FT_BASEPIS, FT_ALIQPIS, FT_VALPIS , F2_TOTFED , F2_TOTEST , "
+	cQuery += CRLF + "          FT_BASECOF, FT_ALIQCOF, FT_VALCOF , FT_BASECF3, FT_ALIQCF3, FT_VALCF3 , FT_BASEPS3, FT_ALIQPS3, FT_VALPS3, "
+	cQuery += CRLF + "          FT_BASEIRR, FT_ALIQIRR, FT_VALIRR , F3_OUTRIPI, F3_ISENIPI, F3_OUTRICM, F3_ISENICM, "
+	cQuery += CRLF + "          FT_BASEINS, FT_ALIQINS, D2_ABATINS, FT_VALINS , D2_UM     , D2_QUANT  , "
+	cQuery += CRLF + "          D2_BASEISS, D2_ALIQISS, D2_ABATISS, D2_ABATMAT, D2_VALISS , D2_ITEMCC , "
+	cQuery += CRLF + "          FT_BASECSL, FT_ALIQCSL, FT_VALCSL , D2_CUSTO1 , VRK_CHASSI, VRJ_CODCLI, VRJ_LOJA  , C6_XVLCOM , "
+	cQuery += CRLF + "          C6_TNATREC,  C6_NFORI , C6_FILIAL , C6_NUM    , VV3_TIPVEN, VV3_DESCRI, VRJ_CLIRET, VRK_OPCION, F2_VALBRUT ,D2_DESCZFR , D2_VRDICMS "
 
-	cQuery += " ORDER BY SD2.D2_FILIAL, SD2.D2_DOC, SD2.D2_SERIE, SD2.D2_CLIENTE, SD2.D2_LOJA " 						    + CRLF
+	cQuery += CRLF + " ORDER BY SD2.D2_FILIAL, SD2.D2_DOC, SD2.D2_SERIE, SD2.D2_CLIENTE, SD2.D2_LOJA "
 
 	cQuery := ChangeQuery(cQuery)
 
@@ -737,16 +746,16 @@ Static Function zRel0003( nVlIPIRegi, nVlIPIPres, cEspecie, cDoc, cSerie, cCodCl
 		( cAliasTRB )->( DbCloseArea() )
 	EndIf
 
-	cQry := " SELECT CDA_CODLAN, CDA_VALOR " 					+ CRLF
-	cQry += " FROM " + RetSQLName( 'CDA' ) + ' CDA ' 			+ CRLF
-	cQry += " WHERE CDA_FILIAL = '" + FWxFilial('SF2') + "' "	+ CRLF
-	cQry += " 	AND CDA_ESPECI = '" + cEspecie + "' "			+ CRLF
-	cQry += " 	AND CDA_NUMERO = '" + cDoc + "' "				+ CRLF
-	cQry += " 	AND CDA_SERIE = '" + cSerie + "' "				+ CRLF
-	cQry += " 	AND CDA_CLIFOR = '" + cCodCli + "' "			+ CRLF
-	cQry += " 	AND CDA_LOJA = '" + cCodLoja + "' "				+ CRLF
-	cQry += " 	AND CDA_NUMITE = '" + cItem + "' "				+ CRLF
-	cQry += " 	AND D_E_L_E_T_ = ' ' "							+ CRLF
+	cQry := CRLF + " SELECT CDA_CODLAN, CDA_VALOR "
+	cQry += CRLF + " FROM " + RetSQLName( 'CDA' ) + ' CDA '
+	cQry += CRLF + " WHERE  CDA_FILIAL = '" + FWxFilial('SF2') + "' "
+	cQry += CRLF + " 	AND CDA_ESPECI = '" + cEspecie + "' "
+	cQry += CRLF + " 	AND CDA_NUMERO = '" + cDoc     + "' "
+	cQry += CRLF + " 	AND CDA_SERIE  = '" + cSerie   + "' "
+	cQry += CRLF + " 	AND CDA_CLIFOR = '" + cCodCli  + "' "
+	cQry += CRLF + " 	AND CDA_LOJA   = '" + cCodLoja + "' "
+	cQry += CRLF + " 	AND CDA_NUMITE = '" + cItem    + "' "
+	cQry += CRLF + " 	AND D_E_L_E_T_ = ' ' "
 
 	cQry := ChangeQuery(cQry)
 

--- a/SIGAFIS/Relatorio/ZFISR012.prw
+++ b/SIGAFIS/Relatorio/ZFISR012.prw
@@ -49,6 +49,7 @@ Static Function zSelect(nRadio)
 	Local cArquivo	:= ""
 	Private cPergR1	:= "ZFISR001R1"
 	Private cPergR2	:= "ZFISR001R2"
+	Private lMvNFLeiZF := SuperGetMV("MV_NFLEIZF",,.F.)
 
 	If nRadio == 1
 		If Pergunte( cPergR1	,.T.	)
@@ -116,6 +117,7 @@ Static Function zRel0001(cArquivo)
 	Local cCodNatur		:= ""
 	Local cCodChassi	:= ""
 	Local nVlCom		:= 0
+	Local nTotal 		:= 0
 
 	If !ApOleClient( "MSExcel" )
 		MsgAlert( "Microsoft Excel não instalado!!" )
@@ -251,11 +253,10 @@ Static Function zRel0001(cArquivo)
 
 	If !Empty( MV_PAR18 )
 		cQuery += " 	AND SD1.D1_CF = '" + MV_PAR18 + "' " 																		+ CRLF
-	EndIf  
+	EndIf
 
-
-    If !Empty( MV_PAR23) .OR. !Empty( MV_PAR24 )
-	   cQuery += " 	AND SD1.D1_CHASSI BETWEEN '" + MV_PAR23 + "' AND '" + MV_PAR24 + "' " 												+ CRLF
+    If !Empty( MV_PAR22) .OR. !Empty( MV_PAR23 )
+	   cQuery += " 	AND SD1.D1_CHASSI BETWEEN '" + MV_PAR22 + "' AND '" + MV_PAR23 + "' " 												+ CRLF
     EndIf
 
 	cQuery += " GROUP BY 	D1_FILIAL, D1_COD, D1_DOC, D1_SERIE, D1_TES, D1_CF, D1_FORNECE, D1_LOJA, D1_EMISSAO, D1_DTDIGIT, " 		+ CRLF
@@ -656,6 +657,12 @@ Static Function zRel0001(cArquivo)
 			zRel0003(@nVlIPIRegi, @nVlIPIPres, (cAliasTRB)->F1_ESPECIE, (cAliasTRB)->F1_DOC, (cAliasTRB)->F1_SERIE,;
 					(cAliasTRB)->D1_FORNECE, (cAliasTRB)->D1_LOJA, (cAliasTRB)->D1_ITEM )
 
+			if !lMvNFLeiZF
+				nTotal := (cAliasTRB)->D1_TOTAL  
+			Else
+                nTotal := (cAliasTRB)->D1_TOTAL - ((cAliasTRB)->D1_DESCZFP + (cAliasTRB)->D1_DESCZFC) //--Valor Total Item
+			EndIF
+			
 			oFWMSExcel:AddRow( cAba1	,cTabela1	,{ 	cCgcCpf,;    //--Cnpj/Cpf 
 														cIncEst,;    //--Insc.Estadual
 														cTpPessoa,;    //--Pessoa Fisica/Juridica
@@ -664,12 +671,12 @@ Static Function zRel0001(cArquivo)
 														Alltrim( (cAliasTRB)->F4_FINALID ),;    //--Finalidade TES
 														AllTrim( (cAliasTRB)->B1_ORIGEM ),;    //--Origem do Produto
 														AllTrim( (cAliasTRB)->B1_POSIPI ),;    //--NCM
-														AllTrim( (cAliasTRB)->B1_EX_NCM ),;    //--Ex-NBM
+														AllTrim( (cAliasTRB)->B1_EX_NCM ),;    //--Ex-NCM
 														AllTrim( cModVei ),;    //--Modelo Veículo
 														AllTrim( (cAliasTRB)->VRK_OPCION ),;    //--Opcional
 														AllTrim( (cAliasTRB)->B1_GRUPO ),;    //--Grupo\Linha
 														AllTrim( Posicione("SBM",1,xFilial("SBM")+(cAliasTRB)->B1_GRUPO,"BM_DESC") ),;    //--Descrição do Grupo
-														(cAliasTRB)->D1_TOTAL,;    //--Valor Total Item
+														nTotal ,; //(cAliasTRB)->D1_TOTAL,;    //--Valor Total Item
 														(cAliasTRB)->D1_CF,;    //--Cfop
 														(cAliasTRB)->FT_VALCONT,;    //--Valor Contábil
 														(cAliasTRB)->FT_BASEICM,;    //--Base ICMS
@@ -892,7 +899,6 @@ Static Function zRel0001(cArquivo)
 			oFWMsExcel:AddColumn( cAba2	,cTabela2	,"Chave NFe"			,2	,1	,.F.	) // Center - Texto
 			oFWMsExcel:AddColumn( cAba2	,cTabela2	,"Descrição"			,2	,1	,.F.	) // Center - Texto
 
-
 			While (cTMPCanc)->(!EoF())
 				
 				oFWMSExcel:AddRow( cAba2	, cTabela2	, { Alltrim( (cTMPCanc)->F3_FILIAL ),;    //--Empresa
@@ -992,8 +998,10 @@ Static Function zRel0002(cArquivo)
 	Local nTotReg		:= ""
 	Local nVlIPIRegi	:= 0
 	Local nVlIPIPres	:= 0
-	
-
+	Local nDesconto		:= 0
+	Local nDesVrIcms	:= 0
+	Local nTotal		:= 0
+	Local nVlrDesc      := 0
 	If !ApOleClient("MSExcel")
 		MsgAlert("Microsoft Excel não instalado!")
 		Return
@@ -1008,19 +1016,20 @@ Static Function zRel0002(cArquivo)
 	cQuery += " B1_DESC, B1_XDESCL1, B1_GRUPO, B1_POSIPI, B1_CEST, B1_ORIGEM, B1_EX_NCM, D2_ITEM, "							+ CRLF
 	cQuery += " F2_ESPECIE,F2_CODNFE,F2_MENNOTA,F2_USERLGI,F2_USERLGA,F2_TIPO, FT_CHVNFE,F2_DOC, F2_SERIE, F2_FIMP,  " 		+ CRLF
 	cQuery += " FT_VALCONT, F2_FORMUL, D2_CONTA, D2_NFORI, D2_SERIORI, D2_PRUNIT,D2_TOTAL, "								+ CRLF
-	cQuery += " D2_DESC, FT_CLASFIS, D2_DESCZFP, D2_DESCZFC, D2_TIPO, "														+ CRLF
+	cQuery += " D2_DESC, FT_CLASFIS, D2_DESCZFP, D2_DESCZFC, D2_TIPO, D2_DESCON,"														+ CRLF
 	cQuery += " FT_BASEICM, FT_ALIQICM, FT_VALICM, C6_CHASSI, "																+ CRLF
 	cQuery += " FT_BASEIPI, FT_ALIQIPI, FT_VALIPI, FT_ARETPIS, FT_ARETCOF, FT_VRETPIS, FT_VRETCOF, FT_BRETPIS, "			+ CRLF
 	cQuery += " FT_BASERET, FT_ICMSRET, FT_DIFAL, FT_BRETCOF, "																+ CRLF
 	cQuery += " D2_BASIMP6,D2_ALQIMP6,D2_VALIMP6,   " 																		+ CRLF
 	cQuery += " D2_BASIMP5,D2_ALQIMP5,D2_VALIMP5,   " 																		+ CRLF
+	cQuery += " D2_DESPESA, D2_SEGURO, D2_VALFRE,	"		 																+ CRLF
 	cQuery += " FT_BASEPIS,FT_ALIQPIS,FT_VALPIS, F2_TOTFED, F2_TOTEST, "													+ CRLF
 	cQuery += " FT_BASECOF,FT_ALIQCOF,FT_VALCOF, FT_BASECF3, FT_ALIQCF3, FT_VALCF3, FT_BASEPS3, FT_ALIQPS3, FT_VALPS3, "	+ CRLF
 	cQuery += " FT_BASEIRR,FT_ALIQIRR,FT_VALIRR, F3_OUTRIPI, F3_ISENIPI, F3_OUTRICM, F3_ISENICM,  "							+ CRLF
 	cQuery += " FT_BASEINS,FT_ALIQINS,D2_ABATINS,FT_VALINS, D2_UM, D2_QUANT, "												+ CRLF
 	cQuery += " D2_BASEISS,D2_ALIQISS,D2_ABATISS,D2_ABATMAT,D2_VALISS, D2_ITEMCC, "											+ CRLF
 	cQuery += " FT_BASECSL,FT_ALIQCSL,FT_VALCSL, D2_CUSTO1, VRK_CHASSI, VRJ_CODCLI, VRJ_LOJA, C6_XVLCOM, "					+ CRLF
-	cQuery += " C6_TNATREC, C6_NFORI, C6_FILIAL, C6_NUM, VV3_TIPVEN, VV3_DESCRI, VRJ_CLIRET, VRK_OPCION "					+ CRLF
+	cQuery += " C6_TNATREC, C6_NFORI, C6_FILIAL, C6_NUM, VV3_TIPVEN, VV3_DESCRI, VRJ_CLIRET, VRK_OPCION,D2_DESCZFR , D2_VRDICMS " + CRLF
 	cQuery += " FROM   " + RetSQLName("SD2") + " SD2 " 																		+ CRLF
 	
 	cQuery += "	INNER JOIN " + RetSQLName("SF2") + " SF2 "																+ CRLF
@@ -1128,19 +1137,20 @@ Static Function zRel0002(cArquivo)
 	cQuery += " B1_DESC, B1_XDESCL1, B1_GRUPO, B1_POSIPI, B1_CEST, B1_ORIGEM, B1_EX_NCM, D2_ITEM, "							+ CRLF
 	cQuery += " F2_ESPECIE,F2_CODNFE,F2_MENNOTA,F2_USERLGI,F2_USERLGA,F2_TIPO, FT_CHVNFE,F2_DOC, F2_SERIE, F2_FIMP,  " 		+ CRLF
 	cQuery += " FT_VALCONT, F2_FORMUL, D2_CONTA, D2_NFORI, D2_SERIORI, D2_PRUNIT,D2_TOTAL, "								+ CRLF
-	cQuery += " D2_DESC, FT_CLASFIS, D2_DESCZFP, D2_DESCZFC, D2_TIPO, "														+ CRLF
+	cQuery += " D2_DESC, FT_CLASFIS, D2_DESCZFP, D2_DESCZFC, D2_TIPO,D2_DESCON, "														+ CRLF
 	cQuery += " FT_BASEICM, FT_ALIQICM, FT_VALICM, C6_CHASSI, "																+ CRLF
 	cQuery += " FT_BASEIPI, FT_ALIQIPI, FT_VALIPI, FT_ARETPIS, FT_ARETCOF, FT_VRETPIS, FT_VRETCOF, FT_BRETPIS, "			+ CRLF
 	cQuery += " FT_BASERET, FT_ICMSRET, FT_DIFAL, FT_BRETCOF, "																+ CRLF
 	cQuery += " D2_BASIMP6,D2_ALQIMP6,D2_VALIMP6,   " 																		+ CRLF
 	cQuery += " D2_BASIMP5,D2_ALQIMP5,D2_VALIMP5,   " 																		+ CRLF
+	cQuery += " D2_DESPESA, D2_SEGURO, D2_VALFRE,	"		 																+ CRLF
 	cQuery += " FT_BASEPIS,FT_ALIQPIS,FT_VALPIS, F2_TOTFED, F2_TOTEST, " 													+ CRLF
 	cQuery += " FT_BASECOF,FT_ALIQCOF,FT_VALCOF, FT_BASECF3, FT_ALIQCF3, FT_VALCF3, FT_BASEPS3, FT_ALIQPS3, FT_VALPS3, "	+ CRLF
 	cQuery += " FT_BASEIRR,FT_ALIQIRR,FT_VALIRR, F3_OUTRIPI, F3_ISENIPI, F3_OUTRICM, F3_ISENICM,  "							+ CRLF
 	cQuery += " FT_BASEINS,FT_ALIQINS,D2_ABATINS,FT_VALINS, D2_UM, D2_QUANT, "												+ CRLF
 	cQuery += " D2_BASEISS,D2_ALIQISS,D2_ABATISS,D2_ABATMAT,D2_VALISS, D2_ITEMCC, "											+ CRLF
 	cQuery += " FT_BASECSL,FT_ALIQCSL,FT_VALCSL, D2_CUSTO1, VRK_CHASSI, VRJ_CODCLI, VRJ_LOJA, C6_XVLCOM,  "					+ CRLF
-	cQuery += " C6_TNATREC, C6_NFORI, C6_FILIAL, C6_NUM, VV3_TIPVEN, VV3_DESCRI, VRJ_CLIRET, VRK_OPCION "					+ CRLF
+	cQuery += " C6_TNATREC, C6_NFORI, C6_FILIAL, C6_NUM, VV3_TIPVEN, VV3_DESCRI, VRJ_CLIRET, VRK_OPCION,D2_DESCZFR, D2_VRDICMS"					+ CRLF
 
 	cQuery += " ORDER BY SD2.D2_FILIAL, SD2.D2_DOC, SD2.D2_SERIE, SD2.D2_CLIENTE, SD2.D2_LOJA " 						+ CRLF
 
@@ -1152,7 +1162,7 @@ Static Function zRel0002(cArquivo)
 	DbSelectArea((cAliasTRB))
 	nTotReg := Contar(cAliasTRB,"!Eof()")
 	(cAliasTRB)->(dbGoTop())
-	
+
 	If (cAliasTRB)->(!Eof())
 
 		// Criando o objeto que irá gerar o conteúdo do Excel.
@@ -1504,9 +1514,9 @@ Static Function zRel0002(cArquivo)
 
 			If SC5->( DbSeek( (cAliasTRB)->C6_FILIAL + (cAliasTRB)->C6_NUM ) )
 				cNumPed 	:= SC5->C5_NUM
-				nVlrFrete 	:= SC5->C5_FRETE
-				nVlrSeguro	:= SC5->C5_SEGURO
-				nVlrDesp	:= SC5->C5_DESPESA
+				//nVlrFrete 	:= SC5->C5_FRETE
+				//nVlrSeguro	:= SC5->C5_SEGURO
+				//nVlrDesp	:= SC5->C5_DESPESA
 				cMenNota	:= AllTrim( SC5->C5_MENNOTA )
 				cMenPad		:= AllTrim( SC5->C5_MENPAD )
 				cNaturez	:= AllTrim( SC5->C5_NATUREZ )
@@ -1518,142 +1528,157 @@ Static Function zRel0002(cArquivo)
 			nVlIPIPres := 0
 			//-- Retorna Valor de IPI regional e presumido
 			zRel0003(@nVlIPIRegi, @nVlIPIPres, (cAliasTRB)->F2_ESPECIE, (cAliasTRB)->F2_DOC, (cAliasTRB)->F2_SERIE,;
-					(cAliasTRB)->D2_CLIENTE, (cAliasTRB)->D2_LOJA, (cAliasTRB)->D2_ITEM )	
+					(cAliasTRB)->D2_CLIENTE, (cAliasTRB)->D2_LOJA, (cAliasTRB)->D2_ITEM )
 
-			oFWMSExcel:AddRow( cAba1	, cTabela1	, { cCgcCpf,;    //--Cnpj/Cpf
-														cCGCLocEnt,;    //--CNPJ Loc. Entr.
-														cIncEst,;    //--Insc.Estadual
-														cTpPessoa,;    //--Pessoa Fisica/Juridica
-														cEstCli,;    //--UF
+			nVlrFrete 	:= (cAliasTRB)->D2_VALFRE
+			nVlrSeguro	:= (cAliasTRB)->D2_SEGURO
+			nVlrDesp	:= (cAliasTRB)->D2_DESPESA
+			nDesconto   := (cAliasTRB)->D2_DESCON
+        	nDesVrIcms  := 0
+			If  (cAliasTRB)->D2_VRDICMS > 0  .and. nDesconto >= (cAliasTRB)->D2_VRDICMS 
+				nDesVrIcms := (cAliasTRB)->D2_VRDICMS
+			EndIF
+        
+        	if !lMvNFLeiZF
+				nTotal := ((cAliasTRB)->D2_TOTAL  + nDesconto + (cAliasTRB)->D2_DESCZFR ) - nDesVrIcms 
+			Else
+                nTotal := ((cAliasTRB)->D2_TOTAL  + nDesconto + (cAliasTRB)->D2_DESCZFR ) - ( (cAliasTRB)->D2_DESCZFP + (cAliasTRB)->D2_DESCZFC + nDesVrIcms )  //--Valor Total Item
+			EndIF
+			nVlrDesc := nDesconto
+			oFWMSExcel:AddRow( cAba1	, cTabela1	, { cCgcCpf,;                //--Cnpj/Cpf
+														cCGCLocEnt,;             //--CNPJ Loc. Entr.
+														cIncEst,;                //--Insc.Estadual
+														cTpPessoa,;              //--Pessoa Fisica/Juridica
+														cEstCli,;                //--UF
 														(cAliasTRB)->D2_TES,;    //--Tes
 														Alltrim( (cAliasTRB)->F4_FINALID ),;    //--Finalidade TES
-														AllTrim( (cAliasTRB)->B1_ORIGEM ),;    //--Origem do Produto
-														AllTrim( (cAliasTRB)->B1_POSIPI ),;    //--NCM
-														AllTrim( (cAliasTRB)->B1_EX_NCM ),;    //--Ex-NBM
-														AllTrim( cModVei ),;    //--Modelo Veículo
+														AllTrim( (cAliasTRB)->B1_ORIGEM ),;     //--Origem do Produto
+														AllTrim( (cAliasTRB)->B1_POSIPI ),;     //--NCM
+														AllTrim( (cAliasTRB)->B1_EX_NCM ),;     //--Ex-NBM
+														AllTrim( cModVei ),;                    //--Modelo Veículo
 														AllTrim( (cAliasTRB)->VRK_OPCION ),;    //--Opcional
-														AllTrim( (cAliasTRB)->B1_GRUPO ),;    //--Grupo\Linha
+														AllTrim( (cAliasTRB)->B1_GRUPO ),;      //--Grupo\Linha
 														AllTrim( Posicione("SBM",1,xFilial("SBM")+(cAliasTRB)->B1_GRUPO,"BM_DESC") ),;    //--Descrição do Grupo
-														(cAliasTRB)->D2_TOTAL,;    //--Valor Total Item
-														(cAliasTRB)->D2_CF,;    //--Cfop
+														nTotal,;    //--Valor Total Item
+														(cAliasTRB)->D2_CF,;         //--Cfop
 														(cAliasTRB)->FT_VALCONT,;    //--Valor Contábil
-														(cAliasTRB)->FT_BASEICM,;    //--Base ICMS
-														(cAliasTRB)->FT_ALIQICM,;    //--Aliq. ICMS
-														(cAliasTRB)->FT_VALICM,;    //--Valor ICMS
-														(cAliasTRB)->C6_XVLCOM,;    //--Comissão
+														iif( Alltrim((cAliasTRB)->F2_ESPECIE) <> "RPS",(cAliasTRB)->FT_BASEICM , 0 ) ,;    //--Base ICMS
+														iif( Alltrim((cAliasTRB)->F2_ESPECIE) <> "RPS",(cAliasTRB)->FT_ALIQICM , 0 ) ,;    //--Aliq. ICMS
+														iif( Alltrim((cAliasTRB)->F2_ESPECIE) <> "RPS",(cAliasTRB)->FT_VALICM  , 0 ) ,;     //--Valor ICMS
+														(cAliasTRB)->C6_XVLCOM,;     //--Comissão
 														(cAliasTRB)->FT_BASEIPI,;    //--Base IPI
 														(cAliasTRB)->FT_ALIQIPI,;    //--Aliq. IPI
-														(cAliasTRB)->FT_VALIPI,;    //--Valor IPI
-														nVlIPIRegi,;    //--Credito_Regional IPI
-														nVlIPIPres,;    //--Credito_Presumido IPI/Frete
+														(cAliasTRB)->FT_VALIPI,;     //--Valor IPI
+														nVlIPIRegi,;                 //--Credito_Regional IPI
+														nVlIPIPres,;                 //--Credito_Presumido IPI/Frete
 														(cAliasTRB)->FT_BASERET,;    //--Base Subst
 														(cAliasTRB)->FT_ICMSRET,;    //--Valor Subst
 														(cAliasTRB)->FT_BASEPIS,;    //--Base Pis Apuração
 														(cAliasTRB)->FT_ALIQPIS,;    //--Aliq. Pis Apuração
-														(cAliasTRB)->FT_VALPIS,;    //--Valor Pis Apuração
+														(cAliasTRB)->FT_VALPIS,;     //--Valor Pis Apuração
 														(cAliasTRB)->FT_BASECOF,;    //--Base Cofins Apuração
-														(cAliasTRB)->FT_ALIQCOF,;	//--Aliq. Cofins Apuração
-														(cAliasTRB)->FT_VALCOF,;	//--Valor Cofins Apuração
+														(cAliasTRB)->FT_ALIQCOF,;	 //--Aliq. Cofins Apuração
+														(cAliasTRB)->FT_VALCOF,;	 //--Valor Cofins Apuração
 														(cAliasTRB)->FT_BASEPS3,;    //--Base Pis ST ZFM
 														(cAliasTRB)->FT_ALIQPS3,;    //--Aliq. Pis ST ZFM
-														(cAliasTRB)->FT_VALPS3,;	//--Vl. Pis ST ZFM
+														(cAliasTRB)->FT_VALPS3,;	 //--Vl. Pis ST ZFM
 														(cAliasTRB)->FT_BASECF3,;    //--Base Cof ST ZFM
 														(cAliasTRB)->FT_ALIQCF3,;    //--Aliq. Cof ST ZFM
-														(cAliasTRB)->FT_VALCF3,;	//--Vl. Cof ST ZFM
-														(cAliasTRB)->FT_DIFAL,;    //--ICMS Difal
+														(cAliasTRB)->FT_VALCF3,;	 //--Vl. Cof ST ZFM
+														(cAliasTRB)->FT_DIFAL,;      //--ICMS Difal
 														(cAliasTRB)->FT_CLASFIS,;    //--CST ICMS
-														(cAliasTRB)->FT_CTIPI,;    //--CST IPI
-														(cAliasTRB)->FT_CSTPIS,;    //--CST PIS
-														(cAliasTRB)->FT_CSTCOF,;    //--CST COFINS
-														(cAliasTRB)->F4_ICM,;    //--Calcula ICMS
+														(cAliasTRB)->FT_CTIPI,;      //--CST IPI
+														(cAliasTRB)->FT_CSTPIS,;     //--CST PIS
+														(cAliasTRB)->FT_CSTCOF,;     //--CST COFINS
+														(cAliasTRB)->F4_ICM,;        //--Calcula ICMS
 														(cAliasTRB)->F4_CREDICM,;    //--Credita ICMS
-														(cAliasTRB)->F4_IPI,;    //--Calcula IPI
+														(cAliasTRB)->F4_IPI,;        //--Calcula IPI
 														(cAliasTRB)->F4_CREDIPI,;    //--Credita IPI
-														(cAliasTRB)->D2_DOC,;    //--Nota Fiscal
+														(cAliasTRB)->D2_DOC,;        //--Nota Fiscal
 														IIF( AllTrim( (cAliasTRB)->F2_ESPECIE ) == 'NFS', (cAliasTRB)->D2_DOC, ""),;    //--Nf. Prefeitura
-														(cAliasTRB)->D2_SERIE,;    //--Série
+														(cAliasTRB)->D2_SERIE,;      //--Série
 														(cAliasTRB)->F2_ESPECIE,;    //--Espécie
-														AModNot( (cAliasTRB)->F2_ESPECIE ),;    //--Modelo
+														AModNot( (cAliasTRB)->F2_ESPECIE ),;     //--Modelo
 														IIF( Empty( SToD( (cAliasTRB)->D2_EMISSAO ) ), "", SToD( (cAliasTRB)->D2_EMISSAO ) ),;    //--Dt. de Emissão
 														(cAliasTRB)->D2_CLIENTE,;    //--Cliente\Fornecedor
-														(cAliasTRB)->D2_LOJA,;    //--Loja
-														cCliFor,;    //--Nome
-														AllTrim( (cAliasTRB)->C6_CHASSI ),;    //--Chassi
-														(cAliasTRB)->D2_COD,;    //--Cód.Produto
+														(cAliasTRB)->D2_LOJA,;       //--Loja
+														cCliFor,;                    //--Nome
+														AllTrim( (cAliasTRB)->C6_CHASSI ),;      //--Chassi
+														(cAliasTRB)->D2_COD,;        //--Cód.Produto
 														Substr( (cAliasTRB)->B1_DESC,1,20 ),;    //--Descrição do Produto
 														AllTrim( Posicione("SB5",1,xFilial("SB5")+(cAliasTRB)->D2_COD,"B5_CEME") ),;    //--Descrição Científico
 														AllTrim( (cAliasTRB)->B1_XDESCL1 ),;    //--Descrição Longa
-														(cAliasTRB)->D2_UM,;    //--Un Medida
-														(cAliasTRB)->D2_QUANT,;    //--Quant
-														(cAliasTRB)->D2_PRUNIT,;    //--Valor Unit. Item
-														(cAliasTRB)->D2_DESC,;    //--Desconto Item
-														nVlrFrete,;    //--Frete
+														(cAliasTRB)->D2_UM,;         //--Un Medida
+														(cAliasTRB)->D2_QUANT,;      //--Quant
+														(cAliasTRB)->D2_PRUNIT,;     //--Valor Unit. Item
+														nVlrDesc ,;     //--Desconto Item
+														nVlrFrete,;     //--Frete
 														nVlrSeguro,;    //--Seguro
-														nVlrDesp,;    //--Despesas
-														(cAliasTRB)->D2_CUSTO1,;    //--Custo
-														(cAliasTRB)->D2_CONTA,;    //--Conta Contábil
+														nVlrDesp,;      //--Despesas
+														(cAliasTRB)->D2_CUSTO1,;     //--Custo
+														(cAliasTRB)->D2_CONTA,;      //--Conta Contábil
 														AllTrim( Posicione("CT1",1,xFilial("CT1")+(cAliasTRB)->D2_CONTA,"CT1_DESC01") ),;    //--Desc.Conta Contábil
 														AllTrim( (cAliasTRB)->D2_FILIAL ),;    //--Empresa
-														cSituacao,;    //--Situação
-														cTpNF,;    //--Tipo Nota Fiscal
-														(cAliasTRB)->FT_CHVNFE,;    //--Chave Nota Fiscal
-														cProtocolo,;    //--Protocolo
+														cSituacao,;                  //--Situação
+														cTpNF,;                      //--Tipo Nota Fiscal
+														(cAliasTRB)->FT_CHVNFE,;     //--Chave Nota Fiscal
+														cProtocolo,;                 //--Protocolo
 														AllTrim( (cAliasTRB)->D2_NFORI ) + " - " + AllTrim( (cAliasTRB)->D2_SERIORI ),;    //--Nota Fiscal Origem
-														cDescTipo,;    //--Tipo Cli\For
-														cTpCliFor,;    //--Cli\For
+														cDescTipo,;                  //--Tipo Cli\For
+														cTpCliFor,;                  //--Cli\For
 														AllTrim( Posicione("SX5" ,1 ,xFilial("SX5") + "12" + cEstCli,"X5_DESCRI") ) ,;    //--Estado
 														AllTrim( Posicione("CC2" ,1 ,xFilial("CC2") + cEstCli + PadR( cCodMun ,TamSx3("CC2_CODMUN")[1] ) , "CC2_MUN" ) ),;    //--Município
-														AllTrim( (cAliasTRB)->B1_CEST ),;    //--CEST
-														AllTrim( cDesMod ),;    //--Descr. Modelo Veículo
-														AllTrim( cComVei ),;    //--Combustível Veículo
+														AllTrim( (cAliasTRB)->B1_CEST ),;     //--CEST
+														AllTrim( cDesMod ),;         //--Descr. Modelo Veículo
+														AllTrim( cComVei ),;         //--Combustível Veículo
 														AllTrim( (cAliasTRB)->F4_TEXTO ),;    //--Descrição CFOP
-														(cAliasTRB)->F2_CODNFE,;    //--Cód.Verificação
-														cAmbiente,;    //--Ambiente
+														(cAliasTRB)->F2_CODNFE,;     //--Cód.Verificação
+														cAmbiente,;    				 //--Ambiente
 														(cAliasTRB)->FT_BASEIRR,;    //--Base Irrf Retenção
 														(cAliasTRB)->FT_ALIQIRR,;    //--Aliq. Irrf Retenção
-														(cAliasTRB)->FT_VALIRR,;    //--Irrf Retenção
+														(cAliasTRB)->FT_VALIRR,;     //--Irrf Retenção
 														(cAliasTRB)->FT_BASEINS,;    //--Base Inss
 														(cAliasTRB)->FT_ALIQINS,;    //--Aliq. Inss
 														(cAliasTRB)->D2_ABATINS,;    //--Inss Recolhido
-														(cAliasTRB)->FT_VALINS,;    //--Valor Inss
+														(cAliasTRB)->FT_VALINS,;     //--Valor Inss
 														(cAliasTRB)->D2_BASEISS,;    //--Base Iss
 														(cAliasTRB)->D2_ALIQISS,;    //--Aliq. Iss
 														(cAliasTRB)->D2_ABATISS,;    //--Iss Serviços
 														(cAliasTRB)->D2_ABATMAT,;    //--Iss Materiais
-														(cAliasTRB)->D2_VALISS,;	//--Valor Iss
+														(cAliasTRB)->D2_VALISS,;	 //--Valor Iss
 														(cAliasTRB)->FT_BASECSL,;    //--Base Csll
 														IIF( (cAliasTRB)->FT_BASECSL > 0, (cAliasTRB)->FT_ALIQCSL, 0 ),;    //--Aliq. Csll
-														(cAliasTRB)->FT_VALCSL,;    //--Valor Csll
+														(cAliasTRB)->FT_VALCSL,;     //--Valor Csll
 														(cAliasTRB)->FT_BRETPIS,;    //--Base Pis Retenção
 														IIF( (cAliasTRB)->FT_BRETPIS > 0, (cAliasTRB)->FT_ARETPIS, 0 ),;    //--Aliq. Pis Retenção
 														(cAliasTRB)->FT_VRETPIS,;    //--Valor Pis Retenção
 														(cAliasTRB)->FT_BRETCOF,;    //--Base Cofins Retenção
 														IIF( (cAliasTRB)->FT_BRETCOF > 0, (cAliasTRB)->FT_ARETCOF, 0 ),;    //--Aliq. Cofins Retenção
 														(cAliasTRB)->FT_VRETCOF,;    //--Valor Cofins Retenção
-														cLogInc,;    //--Log. de Inclusão
-													  	cLogAlt,;    //--Log. de Alteração
-														cDtLogAlt,;    //--Dt. Log. de Alteração
+														cLogInc,;                    //--Log. de Inclusão
+													  	cLogAlt,;                    //--Log. de Alteração
+														cDtLogAlt,;                  //--Dt. Log. de Alteração
 														AllTrim( (cAliasTRB)->VV3_TIPVEN ),;    //--Tipo Venda
 														AllTrim( (cAliasTRB)->VV3_DESCRI ),;    //--Descr. Tipo Venda
-														cNumPed,;    //--Num. Pedido
-														cNaturez,;    //--Natureza Financeira
+														cNumPed,;                    //--Num. Pedido
+														cNaturez,;                   //--Natureza Financeira
 														AllTrim( (cAliasTRB)->C6_TNATREC ),;    //--Tab. Nat. Receita
-														AllTrim( (cAliasTRB)->D2_ITEMCC ),;    //--Item Contábil
+														AllTrim( (cAliasTRB)->D2_ITEMCC ),;     //--Item Contábil
 														(cAliasTRB)->F3_ISENICM,;    //--ICMS Isento
 														(cAliasTRB)->F3_OUTRICM,;    //--ICMS Outros
 														(cAliasTRB)->F3_ISENIPI,;    //--IPI Isento
 														(cAliasTRB)->F3_OUTRIPI,;    //--IPI Outros
-														cTransp,;    //--Cód. Transportadora
-														(cAliasTRB)->VRJ_CLIRET,; //--Cat. Local de Entrega
-														cNomLocEnt,;    //--Nome Loc. Entr.
-														cUFLocEnt,;    //--UF Loc. Entr.
-														cMsgSefaz,;    //--Msgn Sefaz
+														cTransp,;                    //--Cód. Transportadora
+														(cAliasTRB)->VRJ_CLIRET,;    //--Cat. Local de Entrega
+														cNomLocEnt,;                 //--Nome Loc. Entr.
+														cUFLocEnt,;                  //--UF Loc. Entr.
+														cMsgSefaz,;                  //--Msgn Sefaz
 														(cAliasTRB)->F2_MENNOTA,;    //--Msgn Nota Fiscal   
-														cMenNota,;    //--Mens.p/Nota
-														cMenPad,;    //--Mens. Padrão
-														cMensNFS,;   //--Mensagem NFS	
-														(cAliasTRB)->( F2_TOTFED + F2_TOTEST ),;	//--Vlr. Aprox. dos Tributos	
-														Alltrim( (cAliasTRB)->F4_DUPLIC ) })	//--Gera Duplicata   												    
+														cMenNota,;                   //--Mens.p/Nota
+														cMenPad,;                    //--Mens. Padrão
+														cMensNFS,;                   //--Mensagem NFS	
+														(cAliasTRB)->( F2_TOTFED + F2_TOTEST ),;  //--Vlr. Aprox. dos Tributos	
+														Alltrim( (cAliasTRB)->F4_DUPLIC ) })	  //--Gera Duplicata   												    
 			(cAliasTRB)->(DbSkip())
 		EndDo
 

--- a/SIGAFIS/Relatorio/ZFISR015.prw
+++ b/SIGAFIS/Relatorio/ZFISR015.prw
@@ -1,6 +1,7 @@
 #Include 'Protheus.ch'
 #Include 'Topconn.ch'
 #Include "TOTVS.CH"
+
 /*
 =====================================================================================
 Programa.:              ZFISR001
@@ -48,17 +49,18 @@ Static Function zSelect(nRadio)
 	Local cArquivo	:= ""
 	Private cPergR1	:= "ZFISR001R1"
 	Private cPergR2	:= "ZFISR001R2"
+	Private lMvNFLeiZF := SuperGetMV("MV_NFLEIZF",,.F.)
 
 	If nRadio == 1
 		If Pergunte( cPergR1	,.T.	)
-			cArquivo := cGetFile(cExtens,cTitulo,,cMainPath,.F.)
+			cArquivo := cGetFile(cExtens,cTitulo,,cMainPath,.F.,)
 			If !Empty(cArquivo)
 				Processa({|| zRel0001(cArquivo)}	,"Gerando Relatório de Notas Fiscais de Entrada..."	)
 			EndIf
 		EndIf
 	Else
 		If Pergunte( cPergR2	,.T.	)
-			cArquivo := cGetFile(cExtens,cTitulo,,cMainPath,.F.)
+			cArquivo := cGetFile(cExtens,cTitulo,,cMainPath,.F.,)
 			If !Empty(cArquivo)
 				Processa({|| zRel0002(cArquivo)}	,"Gerando Relatório de Notas Fiscais de Saída..."	)
 			EndIf
@@ -115,6 +117,7 @@ Static Function zRel0001(cArquivo)
 	Local cCodNatur		:= ""
 	Local cCodChassi	:= ""
 	Local nVlCom		:= 0
+	Local nTotal 		:= 0
 
 	If !ApOleClient( "MSExcel" )
 		MsgAlert( "Microsoft Excel não instalado!!" )
@@ -649,6 +652,12 @@ Static Function zRel0001(cArquivo)
 			zRel0003(@nVlIPIRegi, @nVlIPIPres, (cAliasTRB)->F1_ESPECIE, (cAliasTRB)->F1_DOC, (cAliasTRB)->F1_SERIE,;
 					(cAliasTRB)->D1_FORNECE, (cAliasTRB)->D1_LOJA, (cAliasTRB)->D1_ITEM )
 
+			if !lMvNFLeiZF
+				nTotal := (cAliasTRB)->D1_TOTAL  
+			Else
+                nTotal := (cAliasTRB)->D1_TOTAL - ((cAliasTRB)->D1_DESCZFP + (cAliasTRB)->D1_DESCZFC) //--Valor Total Item
+			EndIF
+			
 			oFWMSExcel:AddRow( cAba1	,cTabela1	,{ 	cCgcCpf,;    //--Cnpj/Cpf 
 														cIncEst,;    //--Insc.Estadual
 														cTpPessoa,;    //--Pessoa Fisica/Juridica
@@ -662,7 +671,7 @@ Static Function zRel0001(cArquivo)
 														AllTrim( (cAliasTRB)->VRK_OPCION ),;    //--Opcional
 														AllTrim( (cAliasTRB)->B1_GRUPO ),;    //--Grupo\Linha
 														AllTrim( Posicione("SBM",1,xFilial("SBM")+(cAliasTRB)->B1_GRUPO,"BM_DESC") ),;    //--Descrição do Grupo
-														(cAliasTRB)->D1_TOTAL,;    //--Valor Total Item
+														nTotal ,; //(cAliasTRB)->D1_TOTAL,;    //--Valor Total Item
 														(cAliasTRB)->D1_CF,;    //--Cfop
 														(cAliasTRB)->FT_VALCONT,;    //--Valor Contábil
 														(cAliasTRB)->FT_BASEICM,;    //--Base ICMS
@@ -884,7 +893,6 @@ Static Function zRel0001(cArquivo)
 			oFWMsExcel:AddColumn( cAba2	,cTabela2	,"Chave NFe"			,2	,1	,.F.	) // Center - Texto
 			oFWMsExcel:AddColumn( cAba2	,cTabela2	,"Descrição"			,2	,1	,.F.	) // Center - Texto
 
-
 			While (cTMPCanc)->(!EoF())
 				
 				oFWMSExcel:AddRow( cAba2	, cTabela2	, { Alltrim( (cTMPCanc)->F3_FILIAL ),;    //--Empresa
@@ -985,7 +993,9 @@ Static Function zRel0002(cArquivo)
 	Local nTotReg		:= ""
 	Local nVlIPIRegi	:= 0
 	Local nVlIPIPres	:= 0
-	
+	Local nDesconto		:= 0
+	Local nDesVrIcms	:= 0
+	Local nTotal		:= 0
 
 	If !ApOleClient("MSExcel")
 		MsgAlert("Microsoft Excel não instalado!")
@@ -1014,7 +1024,7 @@ Static Function zRel0002(cArquivo)
 	cQuery += " FT_BASEINS,FT_ALIQINS,D2_ABATINS,FT_VALINS, D2_UM, D2_QUANT, "												+ CRLF
 	cQuery += " D2_BASEISS,D2_ALIQISS,D2_ABATISS,D2_ABATMAT,D2_VALISS, D2_ITEMCC, "											+ CRLF
 	cQuery += " FT_BASECSL,FT_ALIQCSL,FT_VALCSL, D2_CUSTO1, VRK_CHASSI, VRJ_CODCLI, VRJ_LOJA, C6_XVLCOM, "					+ CRLF
-	cQuery += " C6_TNATREC, C6_NFORI, C6_FILIAL, C6_NUM, VV3_TIPVEN, VV3_DESCRI, VRJ_CLIRET, VRK_OPCION "					+ CRLF
+	cQuery += " C6_TNATREC, C6_NFORI, C6_FILIAL, C6_NUM, VV3_TIPVEN, VV3_DESCRI, VRJ_CLIRET, VRK_OPCION,D2_DESCZFR , D2_VRDICMS " + CRLF
 	cQuery += " FROM   " + RetSQLName("SD2") + " SD2 " 																		+ CRLF
 	
 	cQuery += "	INNER JOIN " + RetSQLName("SF2") + " SF2 "																+ CRLF
@@ -1131,7 +1141,7 @@ Static Function zRel0002(cArquivo)
 	cQuery += " FT_BASEINS,FT_ALIQINS,D2_ABATINS,FT_VALINS, D2_UM, D2_QUANT, "												+ CRLF
 	cQuery += " D2_BASEISS,D2_ALIQISS,D2_ABATISS,D2_ABATMAT,D2_VALISS, D2_ITEMCC, "											+ CRLF
 	cQuery += " FT_BASECSL,FT_ALIQCSL,FT_VALCSL, D2_CUSTO1, VRK_CHASSI, VRJ_CODCLI, VRJ_LOJA, C6_XVLCOM,  "					+ CRLF
-	cQuery += " C6_TNATREC, C6_NFORI, C6_FILIAL, C6_NUM, VV3_TIPVEN, VV3_DESCRI, VRJ_CLIRET, VRK_OPCION "					+ CRLF
+	cQuery += " C6_TNATREC, C6_NFORI, C6_FILIAL, C6_NUM, VV3_TIPVEN, VV3_DESCRI, VRJ_CLIRET, VRK_OPCION,D2_DESCZFR, D2_VRDICMS"					+ CRLF
 
 	cQuery += " ORDER BY SD2.D2_FILIAL, SD2.D2_DOC, SD2.D2_SERIE, SD2.D2_CLIENTE, SD2.D2_LOJA " 						+ CRLF
 
@@ -1143,7 +1153,7 @@ Static Function zRel0002(cArquivo)
 	DbSelectArea((cAliasTRB))
 	nTotReg := Contar(cAliasTRB,"!Eof()")
 	(cAliasTRB)->(dbGoTop())
-	
+
 	If (cAliasTRB)->(!Eof())
 
 		// Criando o objeto que irá gerar o conteúdo do Excel.
@@ -1509,7 +1519,7 @@ Static Function zRel0002(cArquivo)
 			nVlIPIPres := 0
 			//-- Retorna Valor de IPI regional e presumido
 			zRel0003(@nVlIPIRegi, @nVlIPIPres, (cAliasTRB)->F2_ESPECIE, (cAliasTRB)->F2_DOC, (cAliasTRB)->F2_SERIE,;
-					(cAliasTRB)->D2_CLIENTE, (cAliasTRB)->D2_LOJA, (cAliasTRB)->D2_ITEM )	
+					(cAliasTRB)->D2_CLIENTE, (cAliasTRB)->D2_LOJA, (cAliasTRB)->D2_ITEM )
 
 			nVlrDesc   := 0
 			//Alterado conf. solicitação Silvana 26/05/22	
@@ -1521,6 +1531,20 @@ Static Function zRel0002(cArquivo)
 				nVlrDesc   := (cAliasTRB)->D2_DESCON          //--Desconto
 			ENDIF
 
+			nDesconto   := (cAliasTRB)->D2_DESCON
+        	nDesVrIcms  := 0
+			If  (cAliasTRB)->D2_VRDICMS > 0  .and. nDesconto >= (cAliasTRB)->D2_VRDICMS 
+				nDesVrIcms := (cAliasTRB)->D2_VRDICMS
+			EndIF
+        
+        	if !lMvNFLeiZF
+				nTotal := ((cAliasTRB)->D2_TOTAL  + nDesconto + (cAliasTRB)->D2_DESCZFR ) - nDesVrIcms 
+			Else
+                nTotal := ((cAliasTRB)->D2_TOTAL  + nDesconto + (cAliasTRB)->D2_DESCZFR ) - ( (cAliasTRB)->D2_DESCZFP + (cAliasTRB)->D2_DESCZFC + nDesVrIcms )  //--Valor Total Item
+			EndIF
+
+			nVlrDesc := nDesconto
+
 			oFWMSExcel:AddRow( cAba1	, cTabela1	, { cCgcCpf,;                //--Cnpj/Cpf
 														cCGCLocEnt,;             //--CNPJ Loc. Entr.
 														cIncEst,;                //--Insc.Estadual
@@ -1530,19 +1554,19 @@ Static Function zRel0002(cArquivo)
 														Alltrim( (cAliasTRB)->F4_FINALID ),;    //--Finalidade TES
 														AllTrim( (cAliasTRB)->B1_ORIGEM ),;     //--Origem do Produto
 														AllTrim( (cAliasTRB)->B1_POSIPI ),;     //--NCM
-														AllTrim( (cAliasTRB)->B1_EX_NCM ),;     //--Ex-NCM
+														AllTrim( (cAliasTRB)->B1_EX_NCM ),;     //--Ex-NBM
 														AllTrim( cModVei ),;                    //--Modelo Veículo
 														AllTrim( (cAliasTRB)->VRK_OPCION ),;    //--Opcional
 														AllTrim( (cAliasTRB)->B1_GRUPO ),;      //--Grupo\Linha
 														AllTrim( Posicione("SBM",1,xFilial("SBM")+(cAliasTRB)->B1_GRUPO,"BM_DESC") ),;    //--Descrição do Grupo
-														(cAliasTRB)->D2_TOTAL,;      //--Valor Total Item
+														nTotal,;    //--Valor Total Item
 														(cAliasTRB)->D2_PRUNIT,;     //--Valor Unit. Bruto
 														nVlrDesc,;	//--Valor Desc Item
 														(cAliasTRB)->D2_CF,;         //--Cfop
 														(cAliasTRB)->FT_VALCONT,;    //--Valor Contábil
-														(cAliasTRB)->FT_BASEICM,;    //--Base ICMS
-														(cAliasTRB)->FT_ALIQICM,;    //--Aliq. ICMS
-														(cAliasTRB)->FT_VALICM,;     //--Valor ICMS
+														iif( Alltrim((cAliasTRB)->F2_ESPECIE) <> "RPS",(cAliasTRB)->FT_BASEICM , 0 ),;    //--Base ICMS
+														iif( Alltrim((cAliasTRB)->F2_ESPECIE) <> "RPS",(cAliasTRB)->FT_ALIQICM , 0 ),;    //--Aliq. ICMS
+														iif( Alltrim((cAliasTRB)->F2_ESPECIE) <> "RPS",(cAliasTRB)->FT_VALICM  , 0 ),;     //--Valor ICMS
 														(cAliasTRB)->C6_XVLCOM,;     //--Comissão
 														(cAliasTRB)->FT_BASEIPI,;    //--Base IPI
 														(cAliasTRB)->FT_ALIQIPI,;    //--Aliq. IPI
@@ -1587,11 +1611,11 @@ Static Function zRel0002(cArquivo)
 														AllTrim( Posicione("SB5",1,xFilial("SB5")+(cAliasTRB)->D2_COD,"B5_CEME") ),;    //--Descrição Científico
 														AllTrim( (cAliasTRB)->B1_XDESCL1 ),;     //--Descrição Longa
 														(cAliasTRB)->D2_UM,;         //--Un Medida
-														(cAliasTRB)->D2_QUANT,;      //--Quant										
+														(cAliasTRB)->D2_QUANT,;      //--Quant
 														nVlrFrete,;     //--Frete
 														nVlrSeguro,;    //--Seguro
 														nVlrDesp,;      //--Despesas
-                                                        (cAliasTRB)->D2_CUSTO1,;     //--Custo
+														(cAliasTRB)->D2_CUSTO1,;     //--Custo
 														(cAliasTRB)->D2_CONTA,;      //--Conta Contábil
 														AllTrim( Posicione("CT1",1,xFilial("CT1")+(cAliasTRB)->D2_CONTA,"CT1_DESC01") ),;    //--Desc.Conta Contábil
 														AllTrim( (cAliasTRB)->D2_FILIAL ),;    //--Empresa
@@ -1609,7 +1633,7 @@ Static Function zRel0002(cArquivo)
 														AllTrim( cComVei ),;         //--Combustível Veículo
 														AllTrim( (cAliasTRB)->F4_TEXTO ),;    //--Descrição CFOP
 														(cAliasTRB)->F2_CODNFE,;     //--Cód.Verificação
-														cAmbiente,;                  //--Ambiente
+														cAmbiente,;    				 //--Ambiente
 														(cAliasTRB)->FT_BASEIRR,;    //--Base Irrf Retenção
 														(cAliasTRB)->FT_ALIQIRR,;    //--Aliq. Irrf Retenção
 														(cAliasTRB)->FT_VALIRR,;     //--Irrf Retenção


### PR DESCRIPTION
Chamado: INC0092943

Ao verificar os dados do Relatório com a Geração do XML da NF-e, foi verificado que no relatório o campo de Valor do Item é somente o campo D2_TOTAL.
Enquanto o valor do item na Geração do XML é composto pela seguinte regra
Se (Não for Zona Franca)
--> D2_TOTAL + D2_DESCON + D2_DESCZFR - D2_VRDICMS
Senão
--> ( D2_TOTAL + D2_DESCON + D2_DESCZFR ) - ( D2_DESCZFP + D2_DESCZFC + D2_VRDICMS)

Foi acrescentado a mesma regra no relatório para corrigir o cálculo do valor do item que estava com divergência.

--

Ajustado a Divergência na despesa e desconto, o qual estava pegando do Cabeçalho do pedido, agora está pegando o desconto do Item da Nota fiscal (SD2)

--
Chamado: INC0101871
Ajustado o valor duplicado, pois estava gerando o valor de ISS no campo de INSS, foi corrigido para que o ISS não seja gerado no campo de INSS

Tremo de Entrega
[GAP103-Erro Relatório Para TES 783, o valor das despesas acessórias 5 para modalidade pedido EMERGENCIAL.pdf](https://github.com/Caoa-Montadora-de-Veiculos-Ltda/Protheus/files/13620750/GAP103-Erro.Relatorio.Para.TES.783.o.valor.das.despesas.acessorias.5.para.modalidade.pedido.EMERGENCIAL.pdf)
