### PR TITLE
CHG0033106 | COM006 | Chave duplicada na classificação do Documento de Entrada

### DIFF
--- a/Ponto de Entrada/SD1100I_PE.prw
+++ b/Ponto de Entrada/SD1100I_PE.prw
@@ -1,13 +1,31 @@
 #Include "Totvs.ch"
 #Include "Protheus.ch"
 
-//Este Ponto de entrada é executado durante a inclusão do Documento de Entrada, após a inclusão do item na tabela SD1. O registro no SD1 já se encontra travado (Lock). Será executado uma vez para cada item do Documento de Entrada que está sendo incluída.
+/*
+=======================================================================================
+Programa.:              SD1100I
+Autor....:              
+Data.....:              
+Descricao / Objetivo:   Ponto de Entrada após a Inclusão da SD1 no Documento de Entrada
+Doc. Origem:            
+Solicitante:            
+Uso......:              
+Obs......:              Este Ponto de entrada é executado durante a inclusão do Documento de Entrada, 
+                        após a inclusão do item na tabela SD1. O registro no SD1 já se encontra travado (Lock). 
+                        Será executado uma vez para cada item do Documento de Entrada que está sendo incluída.
+=======================================================================================
+*/
 
 User Function SD1100I()
 //ExecBlock("SD1100I",.F.,.F.,{lConFrete,lConImp,nOper})
 
 If Findfunction("U_CMVEST03")
 	U_CMVEST03()
+EndIf
+
+// Função para validar D1_NUMSEQ duplicado. Se Encontra no Fonte SD1140I_PE.PRW
+If Findfunction("U_fValiNUmSeq")
+    U_fValiNUmSeq()
 EndIf
 
 Return()

--- a/Ponto de Entrada/SD1140I_PE.prw
+++ b/Ponto de Entrada/SD1140I_PE.prw
@@ -1,0 +1,53 @@
+#Include "Totvs.ch"
+#Include "Protheus.ch"
+
+/*
+=======================================================================================
+Programa.:              SD1140I
+Autor....:              TOTVS - Reinaldo Rabelo da Silva
+Data.....:              07/12/23
+Descricao / Objetivo:   Ponto de Entrada após a Inclusão da SD1 na Pré-Nota de Entrada
+Doc. Origem:            
+Solicitante:            
+Uso......:              
+Obs......:
+=======================================================================================
+*/
+
+User Function SD1140I()
+
+If Findfunction("U_fValiNUmSeq")
+    U_fValiNUmSeq()
+EndIf
+
+Return nil
+
+/*
+=======================================================================================
+Programa.:              fValiNUmSeq
+Autor....:              TOTVS - Reinaldo Rabelo da Silva
+Data.....:              07/12/23
+Descricao / Objetivo:   Rotina Para prevenir a Duplicação da D1_NUMSEQ
+Doc. Origem:            
+Solicitante:            
+Uso......:              
+Obs......:              Chamado pelos Pontos de Entradas SD1140I e SD1100I
+=======================================================================================
+*/
+
+User Function fValiNUmSeq()
+
+if Type('cValNumSeq') <> "C"
+    Public cValNumSeq := ""
+EndIF
+
+//Verifica se existe Numero de Sequencia Dulpicado
+If SD1->D1_NUMSEQ $ cValNumSeq
+    //Caso existe Duplicado pega um numero novo para o registro
+    SD1->D1_NUMSEQ := ProxNum()
+
+EndIf
+
+cValNumSeq += SD1->D1_NUMSEQ + "|"
+
+Return


### PR DESCRIPTION
Desenvolvido rotina para verificar se o D1_NUMSEQ está duplicado na inclusão da Pré-Nota e na Classificação do Documento de entrada e corrigindo gerando um  numseq novo.
Foi criado o Ponto de Entrada SD1140I para validar na inclusão da Pré-Nota
Alterado o SD1100I para validar na Classificação da Pré Nota.

**Termo de Entrega**
[GAP109 - Chave duplicada erro na geração da demanda.pdf](https://github.com/Caoa-Montadora-de-Veiculos-Ltda/Protheus/files/13664709/GAP109.-.Chave.duplicada.erro.na.geracao.da.demanda.pdf)
