### PR TITLE
CHG0033131 | COM006.001 | Erro na Classificação de Processo, D0Q_NUMSEQ duplicado

### DIFF
--- a/Ponto de Entrada/SD1140I_PE.prw
+++ b/Ponto de Entrada/SD1140I_PE.prw
@@ -37,6 +37,10 @@ Obs......:              Chamado pelos Pontos de Entradas SD1140I e SD1100I
 
 User Function fValiNUmSeq()
 
+Local aArea := GetArea()
+Local aAreaSD1 := SD1->(GetArea())
+Local aAreaD0Q := D0Q->(GetArea())
+
 if Type('cValNumSeq') <> "C"
     Public cValNumSeq := ""
 EndIF
@@ -45,9 +49,36 @@ EndIF
 If SD1->D1_NUMSEQ $ cValNumSeq
     //Caso existe Duplicado pega um numero novo para o registro
     SD1->D1_NUMSEQ := ProxNum()
+    
+    DBSELECTAREA('D0Q')
+    DbSetOrder(1)
+    
+    //Verifico se existe Demanda do Unitizador para acertar o NUMSEQ também
+    If D0Q->(DBSEEK(XfILIAL('D0Q') + SD1->D1_SERVIC + SD1->D1_DOC + SD1->D1_SERIE + SD1->D1_FORNECE + SD1->D1_LOJA ))
+                
+        While D0Q->(!EOF()) .and. ;
+            SD1->D1_FILIAL  == D0Q->D0Q_FILIAL .AND. SD1->D1_SERVIC == D0Q->D0Q_SERVIC .AND.;
+            SD1->D1_DOC     == D0Q->D0Q_DOCTO  .AND. SD1->D1_SERIE  == D0Q->D0Q_SERIE  .AND. ;
+            SD1->D1_FORNECE == D0Q->D0Q_CLIFOR .AND. SD1->D1_LOJA   == D0Q->D0Q_LOJA
+            
+            //Atualiza a D0Q_NUMSEQ a Tabela de Demanda com o D1_NUMSEQ atualizado
+            If D0Q->D0Q_ID == SD1->D1_IDDCF
+                D0Q->D0Q_NUMSEQ := SD1->D1_NUMSEQ
+                EXIT
+            EndIf
+        
+            D0Q->(DbSkip())
+        EndDo
+
+        RestArea(aAreaD0Q)
+    EndIf
 
 EndIf
 
+//Guardo os NUMSEQ utilizado para validar o Proximo NUMSEQ.
 cValNumSeq += SD1->D1_NUMSEQ + "|"
+
+RestArea(aAreaSD1)
+RestArea(aArea)
 
 Return


### PR DESCRIPTION
Foi verificado que o ponto de entrada SD1100I que chama a função fValiNUmSeq() para acertar o D1_NUMSEQ no fonte SD1140I_PE é executado depois da geração da Demanda do Unitizador.
Feita correção na função fValiNUmSeq() para atualiza a D0Q_NUMSEQ a Tabela de Demanda com o D1_NUMSEQ atualizado

**Termo de Entrega**
[GAP113-Erro na Classificação de Processo (D0Q_NUMSEQ duplicado).pdf](https://github.com/Caoa-Montadora-de-Veiculos-Ltda/Protheus/files/13730591/GAP113-Erro.na.Classificacao.de.Processo.D0Q_NUMSEQ.duplicado.pdf)
