### PR TITLE
CHG0033173 | FIS002.005 | Trazendo valores de ISS nos campos de ICMS no Documento de Entrada

### DIFF
--- a/SIGAFIS/Relatorio/ZFISR001.prw
+++ b/SIGAFIS/Relatorio/ZFISR001.prw
@@ -679,9 +679,9 @@ Static Function zRel0001(cArquivo)
 														nTotal ,; //(cAliasTRB)->D1_TOTAL,;    //--Valor Total Item
 														(cAliasTRB)->D1_CF,;    //--Cfop
 														(cAliasTRB)->FT_VALCONT,;    //--Valor Contábil
-														(cAliasTRB)->FT_BASEICM,;    //--Base ICMS
-														(cAliasTRB)->FT_ALIQICM,;    //--Aliq. ICMS
-														(cAliasTRB)->FT_VALICM,;    //--Valor ICMS
+														iif( Alltrim((cAliasTRB)->F1_ESPECIE) <> "RPS", (cAliasTRB)->FT_BASEICM , 0),;   //(cAliasTRB)->FT_BASEICM,;    //--Base ICMS
+														iif( Alltrim((cAliasTRB)->F1_ESPECIE) <> "RPS", (cAliasTRB)->FT_ALIQICM , 0),;   //(cAliasTRB)->FT_ALIQICM,;    //--Aliq. ICMS
+														iif( Alltrim((cAliasTRB)->F1_ESPECIE) <> "RPS", (cAliasTRB)->FT_VALICM  , 0),;   //(cAliasTRB)->FT_VALICM,;    //--Valor ICMS
 														IIF( (cAliasTRB)->F1_TIPO $ "B|D" , nVlCom , 0 ),;    //--Comissão
 														(cAliasTRB)->FT_BASEIPI,;    //--Base IPI					
 														(cAliasTRB)->FT_ALIQIPI,;    //--Aliq. IPI			

--- a/SIGAFIS/Relatorio/ZFISR003.prw
+++ b/SIGAFIS/Relatorio/ZFISR003.prw
@@ -410,9 +410,9 @@ Static Function  ReportPrint(oReport)
          oSection:Cell( "D1_TOTAL"  ):SetValue( (cAliasTMP)->D1_TOTAL                                                                                       ) //--Valor Total Item
          oSection:Cell( "D1_CF"     ):SetValue( (cAliasTMP)->D1_CF                                                                                          ) //--Cfop
          oSection:Cell( "FT_VALCONT"):SetValue( (cAliasTMP)->FT_VALCONT                                                                                     ) //--Valor Contábil
-         oSection:Cell( "FT_BASEICM"):SetValue( (cAliasTMP)->FT_BASEICM                                                                                     ) //--Base ICMS
-         oSection:Cell( "FT_ALIQICM"):SetValue( (cAliasTMP)->FT_ALIQICM                                                                                     ) //--Aliq. ICMS
-         oSection:Cell( "FT_VALICM" ):SetValue( (cAliasTMP)->FT_VALICM                                                                                      ) //--Valor ICMS
+         oSection:Cell( "FT_BASEICM"):SetValue( iif( Alltrim((cAliasTMP)->F1_ESPECIE) <> "RPS", (cAliasTMP)->FT_BASEICM , 0)                                ) //(cAliasTMP)->FT_BASEICM   ) //--Base ICMS
+         oSection:Cell( "FT_ALIQICM"):SetValue( iif( Alltrim((cAliasTMP)->F1_ESPECIE) <> "RPS", (cAliasTMP)->FT_ALIQICM , 0)                                ) //(cAliasTMP)->FT_ALIQICM   ) //--Aliq. ICMS
+         oSection:Cell( "FT_VALICM" ):SetValue( iif( Alltrim((cAliasTMP)->F1_ESPECIE) <> "RPS", (cAliasTMP)->FT_VALICM  , 0)                                )//(cAliasTMP)->FT_VALICM     ) //--Valor ICMS
          oSection:Cell( "VlCom"     ):SetValue( IIF( (cAliasTMP)->F1_TIPO $ "B|D" , nVlCom , 0 )                                                            ) //--Comissão
          oSection:Cell( "FT_BASEIPI"):SetValue( (cAliasTMP)->FT_BASEIPI                                                                                     ) //--Base IPI					
          oSection:Cell( "FT_ALIQIPI"):SetValue( (cAliasTMP)->FT_ALIQIPI                                                                                     ) //--Aliq. IPI			

--- a/SIGAFIS/Relatorio/ZFISR008.prw
+++ b/SIGAFIS/Relatorio/ZFISR008.prw
@@ -654,10 +654,10 @@ Static Function zRel001B(cArquivo)
 			nTot01   +=  nTotal//iif(valtype((cAliasTRB)->D1_TOTAL)    = "N", (cAliasTRB)->D1_TOTAL   ,0) 				//--Valor Total Item
             aCampo07 :=   (cAliasTRB)->D1_CF                                                      				//--Cfop
 			nTot02   +=  iif(valtype((cAliasTRB)->FT_VALCONT)  = "N", (cAliasTRB)->FT_VALCONT ,0) 				//--Valor Contábil
-			nTot03   +=  iif(valtype((cAliasTRB)->FT_BASEICM)  = "N", (cAliasTRB)->FT_BASEICM ,0) 				//--Base ICMS
-			aCampo08 := (cAliasTRB)->FT_ALIQICM                                                   				//--Aliq. ICMS
-			nTot04   +=  iif(valtype((cAliasTRB)->FT_VALICM)   = "N", (cAliasTRB)->FT_VALICM  ,0) 				//--Valor ICMS
-			aCampo09 := IIF( (cAliasTRB)->F1_TIPO $ "B|D" , nVlCom , 0 )                          				//--Comissão
+			nTot03   +=  iif( Alltrim((cAliasTRB)->F1_ESPECIE) <> "RPS", (cAliasTRB)->FT_BASEICM , 0) 			//--Base ICMS
+			aCampo08 :=  iif( Alltrim((cAliasTRB)->F1_ESPECIE) <> "RPS", (cAliasTRB)->FT_ALIQICM , 0)           //--Aliq. ICMS
+			nTot04   +=  iif( Alltrim((cAliasTRB)->F1_ESPECIE) <> "RPS", (cAliasTRB)->FT_VALICM  , 0) 			//--Valor ICMS
+			aCampo09 :=  IIF( (cAliasTRB)->F1_TIPO $ "B|D" , nVlCom , 0 )                          				//--Comissão
 			nTot05   +=  iif(valtype((cAliasTRB)->FT_BASEIPI)  = "N", (cAliasTRB)->FT_BASEIPI ,0) 				//--Base IPI
 			aCampo10 := (cAliasTRB)->FT_ALIQIPI                                                   				//--Aliq. IPI	
 			nTot06   +=  iif(valtype((cAliasTRB)->FT_VALIPI)   = "N", (cAliasTRB)->FT_VALIPI  ,0) 				//--Valor IPI

--- a/SIGAFIS/Relatorio/ZFISR009.prw
+++ b/SIGAFIS/Relatorio/ZFISR009.prw
@@ -674,9 +674,9 @@ Static Function zRel0001(cArquivo)
 														nTotal ,; //(cAliasTRB)->D1_TOTAL,;    //--Valor Total Item
 														(cAliasTRB)->D1_CF,;    //--Cfop
 														(cAliasTRB)->FT_VALCONT,;    //--Valor Contábil
-														(cAliasTRB)->FT_BASEICM,;    //--Base ICMS
-														(cAliasTRB)->FT_ALIQICM,;    //--Aliq. ICMS
-														(cAliasTRB)->FT_VALICM,;    //--Valor ICMS
+														iif( Alltrim((cAliasTRB)->F1_ESPECIE) <> "RPS", (cAliasTRB)->FT_BASEICM , 0),; //(cAliasTRB)->FT_BASEICM,;    //--Base ICMS
+														iif( Alltrim((cAliasTRB)->F1_ESPECIE) <> "RPS", (cAliasTRB)->FT_ALIQICM , 0),; //(cAliasTRB)->FT_ALIQICM,;    //--Aliq. ICMS
+														iif( Alltrim((cAliasTRB)->F1_ESPECIE) <> "RPS", (cAliasTRB)->FT_VALICM  , 0),; //(cAliasTRB)->FT_VALICM,;    //--Valor ICMS
 														IIF( (cAliasTRB)->F1_TIPO $ "B|D" , nVlCom , 0 ),;    //--Comissão
 														(cAliasTRB)->FT_BASEIPI,;    //--Base IPI					
 														(cAliasTRB)->FT_ALIQIPI,;    //--Aliq. IPI			

--- a/SIGAFIS/Relatorio/ZFISR010.prw
+++ b/SIGAFIS/Relatorio/ZFISR010.prw
@@ -417,9 +417,9 @@ Static Function  ReportPrint(oReport)
          oSection:Cell( "D1_TOTAL"  ):SetValue( (cAliasTMP)->D1_TOTAL ) //--Valor Total Item
          oSection:Cell( "D1_CF"     ):SetValue( (cAliasTMP)->D1_CF ) //--Cfop
          oSection:Cell( "FT_VALCONT"):SetValue( (cAliasTMP)->FT_VALCONT ) //--Valor Contábil
-         oSection:Cell( "FT_BASEICM"):SetValue( (cAliasTMP)->FT_BASEICM ) //--Base ICMS
-         oSection:Cell( "FT_ALIQICM"):SetValue( (cAliasTMP)->FT_ALIQICM ) //--Aliq. ICMS
-         oSection:Cell( "FT_VALICM" ):SetValue( (cAliasTMP)->FT_VALICM ) //--Valor ICMS
+         oSection:Cell( "FT_BASEICM"):SetValue( iif( Alltrim((cAliasTMP)->F1_ESPECIE) <> "RPS", (cAliasTMP)->FT_BASEICM , 0) ) //--Base ICMS
+         oSection:Cell( "FT_ALIQICM"):SetValue( iif( Alltrim((cAliasTMP)->F1_ESPECIE) <> "RPS", (cAliasTMP)->FT_ALIQICM , 0) ) //--Aliq. ICMS
+         oSection:Cell( "FT_VALICM" ):SetValue( iif( Alltrim((cAliasTMP)->F1_ESPECIE) <> "RPS", (cAliasTMP)->FT_VALICM  , 0) ) //--Valor ICMS
          oSection:Cell( "VlCom"     ):SetValue( IIF( (cAliasTMP)->F1_TIPO $ "B|D" , nVlCom , 0 ) ) //--Comissão
          oSection:Cell( "FT_BASEIPI"):SetValue( (cAliasTMP)->FT_BASEIPI ) //--Base IPI					
          oSection:Cell( "FT_ALIQIPI"):SetValue( (cAliasTMP)->FT_ALIQIPI ) //--Aliq. IPI			

--- a/SIGAFIS/Relatorio/ZFISR012.prw
+++ b/SIGAFIS/Relatorio/ZFISR012.prw
@@ -679,9 +679,9 @@ Static Function zRel0001(cArquivo)
 														nTotal ,; //(cAliasTRB)->D1_TOTAL,;    //--Valor Total Item
 														(cAliasTRB)->D1_CF,;    //--Cfop
 														(cAliasTRB)->FT_VALCONT,;    //--Valor Contábil
-														(cAliasTRB)->FT_BASEICM,;    //--Base ICMS
-														(cAliasTRB)->FT_ALIQICM,;    //--Aliq. ICMS
-														(cAliasTRB)->FT_VALICM,;    //--Valor ICMS
+														iif( Alltrim((cAliasTRB)->F1_ESPECIE) <> "RPS", (cAliasTRB)->FT_BASEICM , 0),;    //--Base ICMS
+														iif( Alltrim((cAliasTRB)->F1_ESPECIE) <> "RPS", (cAliasTRB)->FT_ALIQICM , 0),;    //--Aliq. ICMS
+														iif( Alltrim((cAliasTRB)->F1_ESPECIE) <> "RPS", (cAliasTRB)->FT_VALICM  , 0),;    //--Valor ICMS
 														IIF( (cAliasTRB)->F1_TIPO $ "B|D" , nVlCom , 0 ),;    //--Comissão
 														(cAliasTRB)->FT_BASEIPI,;    //--Base IPI					
 														(cAliasTRB)->FT_ALIQIPI,;    //--Aliq. IPI			

--- a/SIGAFIS/Relatorio/ZFISR015.prw
+++ b/SIGAFIS/Relatorio/ZFISR015.prw
@@ -674,9 +674,9 @@ Static Function zRel0001(cArquivo)
 														nTotal ,; //(cAliasTRB)->D1_TOTAL,;    //--Valor Total Item
 														(cAliasTRB)->D1_CF,;    //--Cfop
 														(cAliasTRB)->FT_VALCONT,;    //--Valor Contábil
-														(cAliasTRB)->FT_BASEICM,;    //--Base ICMS
-														(cAliasTRB)->FT_ALIQICM,;    //--Aliq. ICMS
-														(cAliasTRB)->FT_VALICM,;    //--Valor ICMS
+														iif( Alltrim((cAliasTRB)->F1_ESPECIE) <> "RPS", (cAliasTRB)->FT_BASEICM , 0),;    //--Base ICMS
+														iif( Alltrim((cAliasTRB)->F1_ESPECIE) <> "RPS", (cAliasTRB)->FT_ALIQICM , 0),;    //--Aliq. ICMS
+														iif( Alltrim((cAliasTRB)->F1_ESPECIE) <> "RPS", (cAliasTRB)->FT_VALICM  , 0),;    //--Valor ICMS
 														IIF( (cAliasTRB)->F1_TIPO $ "B|D" , nVlCom , 0 ),;    //--Comissão
 														(cAliasTRB)->FT_BASEIPI,;    //--Base IPI					
 														(cAliasTRB)->FT_ALIQIPI,;    //--Aliq. IPI			


### PR DESCRIPTION

Ajustado o valor duplicado, pois estava gerando o valor de ISS no campo de ICMS, foi corrigido para que o ISS não seja gerado no campo de ICMS, para os Relatórios de Entrada, pois os Documento de Saída estão corretos.

**Termo de Entrega**