### PR TITLE
CHG0033192 | MNT002.001 | Ajuste na impressão do nome da filial

### DIFF
--- a/SIGAMNT/Relatorios/ZMNTR001.PRW
+++ b/SIGAMNT/Relatorios/ZMNTR001.PRW
@@ -321,10 +321,13 @@ Static Function zImpCabec()
 
 	//Titulo do relatório: ORDEM DE SERVIÇO DE MANUTENÇÃO
 	oPrint:SayAlign( ( nLinIni + 028 )	,( nColIni )	,cTitulo	,oFont16N	,( nColFim )	,( nLinIni + 25 )	,CLR_BLACK	,2	,2	)
-
+	nLa  := 32
+	nLb  := 42
+	nCoA := 449
+	nCoB := 420
 	//Nome da Empresa
-	oPrint:Say( ( nLinIni + 032 )	,( nColIni + 472 )	,Substr( AllTrim( cFilName ),1 ,At( " ",cFilName )-1 )					,oFont18N	)
-	oPrint:Say( ( nLinIni + 049 )	,( nColIni + 482 )	,Substr( AllTrim( cFilName ),	At( " ",cFilName )+1 , Len( cFilName ) ),oFont18N	)
+	oPrint:Say( ( nLinIni + nLa )	,( nColIni + nCoA )	,PadC(Substr( AllTrim( cFilName ),1 ,At( " ",cFilName )-1 )                 ,30 ) ,oFont10N )
+	oPrint:Say( ( nLinIni + nLb )	,( nColIni + nCoB )	,PadC(Substr( AllTrim( cFilName ),	At( " ",cFilName )+1 , Len( cFilName ) ),30 ) ,oFont10N )
 
 	//Ultima linha dessa seção
 	nLinIni += 055 // Ultima linha dessa seção


### PR DESCRIPTION
Ajustado o Cabeçalho para aparecer o nome da filial por inteiro.

**Termo de Entrega**
[GAP121 -Ajuste da Mensagem da Filial.pdf](https://github.com/Caoa-Montadora-de-Veiculos-Ltda/Protheus/files/13877782/GAP121.-Ajuste.da.Mensagem.da.Filial.pdf)