### PR TITLE
CHG0033285 | FIS002.006 | Ajuste na query para evitar a duplicidade de item

### DIFF
--- a/SIGAFIS/Relatorio/ZFISR001.prw
+++ b/SIGAFIS/Relatorio/ZFISR001.prw
@@ -128,156 +128,176 @@ Static Function zRel0001(cArquivo)
 		(cAliasTRB)->(DbCloseArea())
 	EndIf
 
-	cQuery += " SELECT 	D1_FILIAL, D1_COD, D1_DOC, D1_SERIE, D1_TES, D1_CF, D1_FORNECE, D1_LOJA, D1_EMISSAO, D1_DTDIGIT, " 			+ CRLF
-	cQuery += " D1_ITEM, F4_FINALID, F4_TEXTO, FT_CTIPI, FT_CSTPIS, FT_CSTCOF, F4_ICM, F4_IPI, F4_CREDICM, F4_CREDIPI, F4_DUPLIC, "	+ CRLF
-	cQuery += "	B1_DESC, B1_XDESCL1, B1_GRUPO, B1_POSIPI, B1_CEST, B1_ORIGEM, B1_EX_NCM, "								  			+ CRLF
-	cQuery += "	F1_ESPECIE, F1_CODNFE, F1_MENNOTA, F1_DOC, F1_SERIE, F1_STATUS, F1_TIPO, FT_CHVNFE, "								+ CRLF
-	cQuery += " FT_VALCONT, FT_DESCONT, D1_CONTA, D1_ITEMCTA, D1_NFORI, D1_SERIORI, D1_VUNIT, D1_TOTAL, "							+ CRLF
-	cQuery += " D1_DESC, FT_CLASFIS, FT_BASERET, FT_ICMSRET, D1_DESCZFP, D1_DESCZFC,  "												+ CRLF
-	cQuery += " F1_UFORITR, F1_MUORITR, F1_UFDESTR, F1_MUDESTR,  "																	+ CRLF
-	cQuery += " FT_BASEICM, FT_ALIQICM, FT_VALICM, "																				+ CRLF
-	cQuery += " FT_BASEIPI, FT_ALIQIPI, FT_VALIPI, FT_ARETPIS, FT_ARETCOF, FT_VRETPIS, FT_VRETCOF, FT_BRETPIS, " 					+ CRLF
-	cQuery += " D1_BASIMP6, D1_ALQIMP6, D1_VALIMP6, FT_BRETCOF, " 																	+ CRLF
-	cQuery += " D1_BASIMP5, D1_ALQIMP5, D1_VALIMP5, " 																				+ CRLF
-	cQuery += " FT_BASEPIS, FT_ALIQPIS, FT_VALPIS, FT_ALIQPS3, FT_VALPS3, "															+ CRLF
-	cQuery += " FT_BASECOF, FT_ALIQCOF, FT_VALCOF, FT_DIFAL, FT_BASECF3, FT_ALIQCF3, FT_VALCF3, FT_BASEPS3, "						+ CRLF
-	cQuery += " FT_BASEIRR, FT_ALIQIRR, FT_VALIRR, F3_OUTRIPI, F3_ISENIPI, F3_OUTRICM, F3_ISENICM, " 								+ CRLF
-	cQuery += " FT_BASECSL, FT_ALIQCSL, FT_VALCSL, D1_UM, D1_QUANT, D1_CHASSI, "													+ CRLF
-	cQuery += " FT_BASEINS, FT_ALIQINS, D1_ABATINS, D1_AVLINSS, FT_VALINS, C7_NUM, FT_FORMUL, "										+ CRLF
-	cQuery += " D1_BASEISS, D1_ALIQISS, D1_ABATISS, D1_ABATMAT, D1_VALISS, FT_CODBCC, FT_INDNTFR, "									+ CRLF
-	cQuery += " D1_VALFRE, D1_DESPESA, D1_CUSTO, D1_SEGURO, D1_VALACRS, D1_II, FT_ICMSCOM, D1_TNATREC, D1_CONHEC, "					+ CRLF
-	cQuery += " D1_PESO, FT_MVALPIS, FT_MVALCOF, W6_DTREG_D, W6_DI_NUM, YD_PER_II, VRK_OPCION, W9_TX_FOB, D1_CHASSI "							+ CRLF
+	cQuery += " SELECT 	D1_FILIAL, D1_COD, D1_DOC, D1_SERIE, D1_TES, D1_CF, D1_FORNECE, D1_LOJA, D1_EMISSAO, D1_DTDIGIT, " + CRLF
+	cQuery += " D1_ITEM, F4_FINALID, F4_TEXTO, FT_CTIPI, FT_CSTPIS, FT_CSTCOF, F4_ICM, F4_IPI, F4_CREDICM, F4_CREDIPI, F4_DUPLIC, " + CRLF
+	cQuery += "	B1_DESC, B1_XDESCL1, B1_GRUPO, B1_POSIPI, B1_CEST, B1_ORIGEM, B1_EX_NCM, " + CRLF
+	cQuery += "	F1_ESPECIE, F1_CODNFE, F1_MENNOTA, F1_DOC, F1_SERIE, F1_STATUS, F1_TIPO, FT_CHVNFE, " + CRLF
+	cQuery += " FT_VALCONT, FT_DESCONT, D1_CONTA, D1_ITEMCTA, D1_NFORI, D1_SERIORI, D1_VUNIT, D1_TOTAL, " + CRLF
+	cQuery += " D1_DESC, FT_CLASFIS, FT_BASERET, FT_ICMSRET, D1_DESCZFP, D1_DESCZFC,  " + CRLF
+	cQuery += " F1_UFORITR, F1_MUORITR, F1_UFDESTR, F1_MUDESTR,  " + CRLF
+	cQuery += " FT_BASEICM, FT_ALIQICM, FT_VALICM, " + CRLF
+	cQuery += " FT_BASEIPI, FT_ALIQIPI, FT_VALIPI, FT_ARETPIS, FT_ARETCOF, FT_VRETPIS, FT_VRETCOF, FT_BRETPIS, " + CRLF
+	cQuery += " D1_BASIMP6, D1_ALQIMP6, D1_VALIMP6, FT_BRETCOF, " + CRLF
+	cQuery += " D1_BASIMP5, D1_ALQIMP5, D1_VALIMP5, " + CRLF
+	cQuery += " FT_BASEPIS, FT_ALIQPIS, FT_VALPIS, FT_ALIQPS3, FT_VALPS3, " + CRLF
+	cQuery += " FT_BASECOF, FT_ALIQCOF, FT_VALCOF, FT_DIFAL, FT_BASECF3, FT_ALIQCF3, FT_VALCF3, FT_BASEPS3, " + CRLF
+	cQuery += " FT_BASEIRR, FT_ALIQIRR, FT_VALIRR, F3_OUTRIPI, F3_ISENIPI, F3_OUTRICM, F3_ISENICM, " + CRLF
+	cQuery += " FT_BASECSL, FT_ALIQCSL, FT_VALCSL, D1_UM, D1_QUANT, D1_CHASSI, " + CRLF
+	cQuery += " FT_BASEINS, FT_ALIQINS, D1_ABATINS, D1_AVLINSS, FT_VALINS, C7_NUM, FT_FORMUL, " + CRLF
+	cQuery += " D1_BASEISS, D1_ALIQISS, D1_ABATISS, D1_ABATMAT, D1_VALISS, FT_CODBCC, FT_INDNTFR, " + CRLF
+	cQuery += " D1_VALFRE, D1_DESPESA, D1_CUSTO, D1_SEGURO, D1_VALACRS, D1_II, FT_ICMSCOM, D1_TNATREC, D1_CONHEC, " + CRLF
+	cQuery += " D1_PESO, FT_MVALPIS, FT_MVALCOF, W6_DTREG_D, W6_DI_NUM, 
+	
+	
+	cQuery += "( Select SYD.YD_PER_II from " + RetSqlName("SYD") + " SYD " + CRLF
+ 	cQuery += "	  where SYD.YD_FILIAL  = '" +  FWxFilial('SYD') + "' " + CRLF
+	cQuery += "		AND SYD.YD_TEC     = SB1.B1_POSIPI " + CRLF
+	cQuery += "		AND SYD.YD_EX_NCM  = SB1.B1_EX_NCM " + CRLF
+	cQuery += "		AND SYD.YD_EX_NBM  = SB1.B1_EX_NBM " + CRLF
+    cQuery += "		AND SYD.D_E_L_E_T_ = ' ' " + CRLF
+    cQuery += "		AND     ROWNUM     = 1 " + CRLF
+ 
+    cQuery += "		) as YD_PER_II,  " + CRLF
 
-	cQuery += " FROM " + RetSQLName('SD1') + " SD1 "																				+ CRLF
+	cQuery += " VRK_OPCION, W9_TX_FOB, D1_CHASSI " + CRLF
 
-	cQuery += " INNER JOIN " + RetSQLName('SF1') + " SF1 "			 																+ CRLF
-	cQuery += " 	ON SF1.F1_FILIAL = '" + FWxFilial('SF1') + "' "																	+ CRLF
-	cQuery += " 	AND SF1.F1_DOC = SD1.D1_DOC " 																					+ CRLF
-	cQuery += " 	AND SF1.F1_SERIE = SD1.D1_SERIE " 																				+ CRLF
-	cQuery += " 	AND SF1.F1_FORNECE = SD1.D1_FORNECE " 																			+ CRLF
-	cQuery += " 	AND SF1.F1_LOJA = SD1.D1_LOJA " 																				+ CRLF
-	cQuery += " 	AND SF1.F1_ESPECIE BETWEEN '" +MV_PAR03+ "' AND '" +MV_PAR04+ "' " 												+ CRLF
-	cQuery += " 	AND SF1.D_E_L_E_T_ = ' ' " 																						+ CRLF	
+	cQuery += " FROM " + RetSQLName('SD1') + " SD1 " + CRLF
+
+	cQuery += " INNER JOIN " + RetSQLName('SF1') + " SF1 " + CRLF
+	cQuery += " 	ON  SF1.F1_FILIAL  = '" + FWxFilial('SF1') + "' " + CRLF
+	cQuery += " 	AND SF1.F1_DOC     = SD1.D1_DOC " + CRLF
+	cQuery += " 	AND SF1.F1_SERIE   = SD1.D1_SERIE " + CRLF
+	cQuery += " 	AND SF1.F1_FORNECE = SD1.D1_FORNECE " + CRLF
+	cQuery += " 	AND SF1.F1_LOJA    = SD1.D1_LOJA " + CRLF
+	cQuery += " 	AND SF1.F1_ESPECIE BETWEEN '" + MV_PAR03 + "' AND '" + MV_PAR04 + "' " + CRLF
+	cQuery += " 	AND SF1.D_E_L_E_T_ = ' ' " + CRLF	
 
 	If !Empty(MV_PAR19)
-		cQuery += " 	AND SF1.F1_EST = '" + MV_PAR19 + "' "																		+ CRLF
+		cQuery += " 	AND SF1.F1_EST = '" + MV_PAR19 + "' " + CRLF
 	EndIf 
 
-	cQuery += " INNER JOIN " + RetSQLName("SB1") + " SB1  " 																		+ CRLF
-	cQuery += " 	ON SB1.B1_FILIAL = '" + FWxFilial('SB1') + "'  "																+ CRLF
-	cQuery += "		AND SB1.B1_COD = SD1.D1_COD  "	 																				+ CRLF
-	cQuery += "     AND SB1.D_E_L_E_T_ = ' '   " 																					+ CRLF
+	cQuery += " INNER JOIN " + RetSQLName("SB1") + " SB1  " + CRLF
+	cQuery += " 	ON SB1.B1_FILIAL = '" + FWxFilial('SB1') + "' " + CRLF
+	cQuery += "		AND SB1.B1_COD = SD1.D1_COD  " + CRLF
+	cQuery += "     AND SB1.D_E_L_E_T_ = ' ' " + CRLF
 	
 	If !Empty( MV_PAR20 )
-		cQuery += " 	AND SB1.B1_GRUPO = '" + MV_PAR20 + "' "																		+ CRLF
+		cQuery += " 	AND SB1.B1_GRUPO = '" + MV_PAR20 + "' " + CRLF
 	EndIf
 
 	If !Empty( MV_PAR21 )
-		cQuery += " 	AND SB1.B1_POSIPI = '" + MV_PAR21 + "' "																	+ CRLF
+		cQuery += " 	AND SB1.B1_POSIPI = '" + MV_PAR21 + "' " + CRLF
 	EndIf
 
-	cQuery += " INNER JOIN " + RetSQLName("SF4") + " SF4 " 																			+ CRLF
-	cQuery += " 	ON SF4.F4_FILIAL = '" + FWxFilial('SF4') + "'  "																+ CRLF
-	cQuery += "		AND SF4.F4_CODIGO = SD1.D1_TES  "	 																			+ CRLF
-	cQuery += "     AND SF4.D_E_L_E_T_ = ' '   " 																					+ CRLF
+	cQuery += " INNER JOIN " + RetSQLName("SF4") + " SF4 " + CRLF
+	cQuery += " 	ON  SF4.F4_FILIAL  = '" + FWxFilial('SF4') + "' " + CRLF
+	cQuery += "		AND SF4.F4_CODIGO  = SD1.D1_TES  " + CRLF
+	cQuery += "     AND SF4.D_E_L_E_T_ = ' ' " + CRLF
 
-	cQuery += " LEFT JOIN " + RetSQLName("SW6") + " SW6  " 																			+ CRLF
-	cQuery += " 	ON SW6.W6_FILIAL = '" + FWxFilial('SW6') + "' "																	+ CRLF
-	cQuery += "		AND SW6.W6_HAWB = SD1.D1_CONHEC  "	 																			+ CRLF
-	cQuery += "     AND SW6.D_E_L_E_T_ = ' '   " 																					+ CRLF
+	cQuery += " LEFT JOIN " + RetSQLName("SW6") + " SW6  " + CRLF
+	cQuery += " 	ON  SW6.W6_FILIAL  = '" + FWxFilial('SW6') + "' " + CRLF
+	cQuery += "		AND SW6.W6_HAWB    = SD1.D1_CONHEC " + CRLF
+	cQuery += "     AND SW6.D_E_L_E_T_ = ' ' " + CRLF
 
-	cQuery += " LEFT JOIN " + RetSQLName("SW9") + " SW9  " 																			+ CRLF
-	cQuery += " 	ON SW9.W9_FILIAL = '" + FWxFilial('SW9') + "' "																	+ CRLF
-	cQuery += "		AND SW9.W9_HAWB = SD1.D1_CONHEC  "	 																			+ CRLF
-	cQuery += "     AND SW9.D_E_L_E_T_ = ' '   " 																					+ CRLF
+	cQuery += " LEFT JOIN " + RetSQLName("SW9") + " SW9 " + CRLF
+	cQuery += " 	ON  SW9.W9_FILIAL  = '" + FWxFilial('SW9') + "' " + CRLF
+	cQuery += "		AND SW9.W9_HAWB    = SD1.D1_CONHEC  " + CRLF
+	cQuery += "     AND SW9.D_E_L_E_T_ = ' ' " + CRLF
+/*
+	cQuery += " LEFT JOIN " + RetSQLName("SYD") + " SYD  " 			+ CRLF
+	cQuery += " 	ON SYD.YD_FILIAL = '" + FWxFilial('SYD') + "' "	+ CRLF
+	cQuery += "		AND SYD.YD_TEC = SB1.B1_POSIPI "	 			+ CRLF
+	cQuery += "		AND SYD.YD_EX_NCM = SB1.B1_EX_NCM  "	 		+ CRLF
+	cQuery += "		AND SYD.YD_EX_NBM = SB1.B1_EX_NBM  "	 		+ CRLF
+	cQuery += "     AND SYD.D_E_L_E_T_ = ' '   " 					+ CRLF
+*/
+	cQuery += " LEFT JOIN " + RetSQLName("VVF") + " VVF " + CRLF
+	cQuery += "		ON  VVF.VVF_FILIAL = '" + FWxFilial('VVF') + "' " + CRLF
+	cQuery += " 	AND VVF.VVF_NUMNFI = SF1.F1_DOC " + CRLF
+	cQuery += " 	AND VVF.VVF_SERNFI = SF1.F1_SERIE " + CRLF
+	cQuery += " 	AND VVF.VVF_CODFOR = SF1.F1_FORNECE " + CRLF
+	cQuery += " 	AND VVF.VVF_LOJA   = SF1.F1_LOJA " + CRLF
+	cQuery += " 	AND VVF.D_E_L_E_T_ = ' ' " + CRLF
 
-	cQuery += " LEFT JOIN " + RetSQLName("SYD") + " SYD  " 																			+ CRLF
-	cQuery += " 	ON SYD.YD_FILIAL = '" + FWxFilial('SYD') + "' "																	+ CRLF
-	cQuery += "		AND SYD.YD_TEC = SB1.B1_POSIPI "	 																			+ CRLF
-	cQuery += "		AND SYD.YD_EX_NCM = SB1.B1_EX_NCM  "	 																		+ CRLF
-	cQuery += "		AND SYD.YD_EX_NBM = SB1.B1_EX_NBM  "	 																		+ CRLF
-	cQuery += "     AND SYD.D_E_L_E_T_ = ' '   " 																					+ CRLF
-
-	cQuery += " LEFT JOIN " + RetSQLName("VVF") + " VVF "																			+ CRLF
-	cQuery += "		ON VVF.VVF_FILIAL = '" + FWxFilial('VVF') + "' "																+ CRLF
-	cQuery += " 	AND VVF.VVF_NUMNFI = SF1.F1_DOC "																				+ CRLF
-	cQuery += " 	AND VVF.VVF_SERNFI = SF1.F1_SERIE " 																			+ CRLF
-	cQuery += " 	AND VVF.VVF_CODFOR = SF1.F1_FORNECE " 																			+ CRLF
-	cQuery += " 	AND VVF.VVF_LOJA = SF1.F1_LOJA " 																				+ CRLF
-	cQuery += " 	AND VVF.D_E_L_E_T_ = ' ' "																	 					+ CRLF
-
-	cQuery += " LEFT JOIN " + RetSQLName("SC7") + " SC7 "																			+ CRLF
-	cQuery += " 	ON SC7.C7_FILIAL = '" + FWxFilial('SC7') + "' "																	+ CRLF
-	cQuery += "		AND SC7.C7_NUM = SD1.D1_PEDIDO "																				+ CRLF
-	cQuery += "		AND SC7.C7_ITEM = SD1.D1_ITEMPC "												 								+ CRLF
-	cQuery += "		AND SC7.D_E_L_E_T_ = ' ' "																						+ CRLF
+	cQuery += " LEFT JOIN " + RetSQLName("SC7") + " SC7 " + CRLF
+	cQuery += " 	ON  SC7.C7_FILIAL  = '" + FWxFilial('SC7') + "' " + CRLF
+	cQuery += "		AND SC7.C7_NUM     = SD1.D1_PEDIDO " + CRLF
+	cQuery += "		AND SC7.C7_ITEM    = SD1.D1_ITEMPC " + CRLF
+	cQuery += "		AND SC7.D_E_L_E_T_ = ' ' " + CRLF
 	
-	cQuery += " LEFT JOIN " + RetSQLName("VRK") + " VRK "																			+ CRLF
-	cQuery += " 	ON VRK.VRK_FILIAL = '" + FWxFilial('VRK') + "' "  																+ CRLF
-	cQuery += "		AND VRK.VRK_PEDIDO = SD1.D1_PEDIDO	"																			+ CRLF
-    cQuery += "     AND VRK.VRK_ITEPED = SD1.D1_ITEMPC	"																			+ CRLF
-	cQuery += "     AND VRK.D_E_L_E_T_ = ' '   " 																					+ CRLF
+	cQuery += " LEFT JOIN " + RetSQLName("VRK") + " VRK " + CRLF
+	cQuery += " 	ON  VRK.VRK_FILIAL = '" + FWxFilial('VRK') + "' " + CRLF
+	cQuery += "		AND VRK.VRK_PEDIDO = SD1.D1_PEDIDO	" + CRLF
+    cQuery += "     AND VRK.VRK_ITEPED = SD1.D1_ITEMPC	" + CRLF
+	cQuery += "     AND VRK.D_E_L_E_T_ = ' '   " + CRLF
 
-	cQuery += " INNER JOIN " + RetSQLName("SFT") + " SFT " 																			+ CRLF
-	cQuery += "		ON SFT.FT_FILIAL = '" + FWxFilial('SFT') + "' "																	+ CRLF
-	cQuery += "		AND SFT.FT_TIPOMOV = 'E' "																						+ CRLF
-	cQuery += "		AND SFT.FT_SERIE = SD1.D1_SERIE "																				+ CRLF
-	cQuery += " 	AND SFT.FT_NFISCAL = SD1.D1_DOC "																				+ CRLF
-	cQuery += "		AND SFT.FT_CLIEFOR = SD1.D1_FORNECE " 																			+ CRLF
-	cQuery += "		AND SFT.FT_LOJA = SD1.D1_LOJA " 																				+ CRLF
-	cQuery += "		AND SFT.FT_ITEM = SD1.D1_ITEM " 																				+ CRLF
-	cQuery += "		AND SFT.FT_PRODUTO = SD1.D1_COD " 																				+ CRLF	
-	cQuery += "		AND SFT.D_E_L_E_T_ = ' ' "																						+ CRLF
+	cQuery += " INNER JOIN " + RetSQLName("SFT") + " SFT " + CRLF
+	cQuery += "		ON  SFT.FT_FILIAL  = '" + FWxFilial('SFT') + "' " + CRLF
+	cQuery += "		AND SFT.FT_TIPOMOV = 'E' " + CRLF
+	cQuery += "		AND SFT.FT_SERIE   = SD1.D1_SERIE "	+ CRLF
+	cQuery += " 	AND SFT.FT_NFISCAL = SD1.D1_DOC " + CRLF
+	cQuery += "		AND SFT.FT_CLIEFOR = SD1.D1_FORNECE " + CRLF
+	cQuery += "		AND SFT.FT_LOJA    = SD1.D1_LOJA " + CRLF
+	cQuery += "		AND SFT.FT_ITEM    = SD1.D1_ITEM " + CRLF
+	cQuery += "		AND SFT.FT_PRODUTO = SD1.D1_COD " + CRLF	
+	cQuery += "		AND SFT.D_E_L_E_T_ = ' ' " + CRLF
 
-	cQuery += " INNER JOIN " + RetSQLName("SF3") + " SF3 " 																			+ CRLF
-	cQuery += "		ON SF3.F3_FILIAL = '" + FWxFilial('SF3') + "' "																	+ CRLF
-	cQuery += "		AND SF3.F3_SERIE = SFT.FT_SERIE "																				+ CRLF
-	cQuery += "		AND SF3.F3_NFISCAL = SFT.FT_NFISCAL "																			+ CRLF
-	cQuery += " 	AND SF3.F3_CLIEFOR = SFT.FT_CLIEFOR "																			+ CRLF
-	cQuery += "		AND SF3.F3_LOJA = SFT.FT_LOJA " 																				+ CRLF
-	cQuery += "		AND SF3.F3_IDENTFT = SFT.FT_IDENTF3 " 																			+ CRLF
-	cQuery += "		AND SF3.D_E_L_E_T_ = ' ' "																						+ CRLF
+	cQuery += " INNER JOIN " + RetSQLName("SF3") + " SF3 " + CRLF
+	cQuery += "		ON  SF3.F3_FILIAL  = '" + FWxFilial('SF3') + "' " + CRLF
+	cQuery += "		AND SF3.F3_SERIE   = SFT.FT_SERIE " + CRLF
+	cQuery += "		AND SF3.F3_NFISCAL = SFT.FT_NFISCAL " + CRLF
+	cQuery += " 	AND SF3.F3_CLIEFOR = SFT.FT_CLIEFOR " + CRLF
+	cQuery += "		AND SF3.F3_LOJA    = SFT.FT_LOJA " + CRLF
+	cQuery += "		AND SF3.F3_IDENTFT = SFT.FT_IDENTF3 " + CRLF
+	cQuery += "		AND SF3.D_E_L_E_T_ = ' ' " + CRLF
 
-	cQuery += " WHERE SD1.D1_FILIAL BETWEEN '" + MV_PAR01 + "' AND '" + MV_PAR02 + "' " 											+ CRLF
-	cQuery += " 	AND SD1.D1_DOC BETWEEN '" + MV_PAR05 + "' AND '" + MV_PAR06 + "' " 												+ CRLF
-	cQuery += " 	AND SD1.D1_SERIE BETWEEN '" + MV_PAR07 + "' AND '" + MV_PAR08 + "' " 											+ CRLF
-	cQuery += " 	AND SD1.D1_FORNECE BETWEEN '" + MV_PAR09 + "' AND '" + MV_PAR10 + "' " 											+ CRLF
-	cQuery += " 	AND SD1.D1_DTDIGIT BETWEEN '" + DToS( MV_PAR11 ) + "' AND '" + DToS( MV_PAR12 ) + "' " 							+ CRLF
-	cQuery += " 	AND SD1.D1_EMISSAO BETWEEN '" + DToS( MV_PAR13 ) + "' AND '" + DToS( MV_PAR14 ) + "' " 							+ CRLF
-	cQuery += " 	AND SD1.D1_COD BETWEEN '" + MV_PAR15 + "' AND '" + MV_PAR16 + "' " 												+ CRLF
-	cQuery += " 	AND SD1.D_E_L_E_T_ = ' ' "	 																					+ CRLF
+	cQuery += " WHERE   SD1.D1_FILIAL  BETWEEN '" +       MV_PAR01   + "' AND '" +       MV_PAR02   + "' " + CRLF
+	cQuery += " 	AND SD1.D1_DOC     BETWEEN '" +       MV_PAR05   + "' AND '" +       MV_PAR06   + "' " + CRLF
+	cQuery += " 	AND SD1.D1_SERIE   BETWEEN '" +       MV_PAR07   + "' AND '" +       MV_PAR08   + "' " + CRLF
+	cQuery += " 	AND SD1.D1_FORNECE BETWEEN '" +       MV_PAR09   + "' AND '" +       MV_PAR10   + "' " + CRLF
+	cQuery += " 	AND SD1.D1_DTDIGIT BETWEEN '" + DToS( MV_PAR11 ) + "' AND '" + DToS( MV_PAR12 ) + "' " + CRLF
+	cQuery += " 	AND SD1.D1_EMISSAO BETWEEN '" + DToS( MV_PAR13 ) + "' AND '" + DToS( MV_PAR14 ) + "' " + CRLF
+	cQuery += " 	AND SD1.D1_COD     BETWEEN '" +        MV_PAR15  + "' AND '" +       MV_PAR16   + "' " + CRLF
+	cQuery += " 	AND SD1.D_E_L_E_T_ = ' ' " + CRLF
 
 	If !Empty( MV_PAR17 )
-		cQuery += " 	AND SD1.D1_TES = '" + MV_PAR17 + "' " 																		+ CRLF
+		cQuery += " 	AND SD1.D1_TES = '" + MV_PAR17 + "' " + CRLF
 	EndIf
 
 	If !Empty( MV_PAR18 )
-		cQuery += " 	AND SD1.D1_CF = '" + MV_PAR18 + "' " 																		+ CRLF
+		cQuery += " 	AND SD1.D1_CF = '" + MV_PAR18 + "' " + CRLF
 	EndIf
 
     If !Empty( MV_PAR22) .OR. !Empty( MV_PAR23 )
-	   cQuery += " 	AND SD1.D1_CHASSI BETWEEN '" + MV_PAR22 + "' AND '" + MV_PAR23 + "' " 												+ CRLF
+	   cQuery += " 	AND SD1.D1_CHASSI BETWEEN '" + MV_PAR22 + "' AND '" + MV_PAR23 + "' " + CRLF
     EndIf
 
-	cQuery += " GROUP BY 	D1_FILIAL, D1_COD, D1_DOC, D1_SERIE, D1_TES, D1_CF, D1_FORNECE, D1_LOJA, D1_EMISSAO, D1_DTDIGIT, " 		+ CRLF
-	cQuery += " D1_ITEM, F4_FINALID, F4_TEXTO, FT_CTIPI, FT_CSTPIS, FT_CSTCOF,  F4_ICM, F4_IPI, F4_CREDICM, F4_CREDIPI, F4_DUPLIC, "+ CRLF
-	cQuery += " B1_DESC, B1_XDESCL1, B1_GRUPO, B1_POSIPI, B1_CEST, B1_ORIGEM, B1_EX_NCM, "											+ CRLF
-	cQuery += "	F1_ESPECIE, F1_CODNFE, F1_MENNOTA, F1_DOC, F1_SERIE, F1_STATUS, F1_TIPO, FT_CHVNFE,"								+ CRLF
-	cQuery += " FT_VALCONT, FT_DESCONT, D1_CONTA, D1_ITEMCTA, D1_NFORI, D1_SERIORI, D1_VUNIT, D1_TOTAL, "							+ CRLF
-	cQuery += " D1_DESC, FT_CLASFIS, FT_BASERET, FT_ICMSRET, D1_DESCZFP, D1_DESCZFC,  "												+ CRLF
-	cQuery += " F1_UFORITR, F1_MUORITR, F1_UFDESTR, F1_MUDESTR,  "																	+ CRLF
-	cQuery += " FT_BASEICM, FT_ALIQICM, FT_VALICM, "																				+ CRLF
-	cQuery += " FT_BASEIPI, FT_ALIQIPI, FT_VALIPI, FT_ARETPIS, FT_ARETCOF, FT_VRETPIS, FT_VRETCOF, FT_BRETPIS, " 					+ CRLF
-	cQuery += " D1_BASIMP6, D1_ALQIMP6, D1_VALIMP6, FT_BRETCOF, " 																	+ CRLF
-	cQuery += " D1_BASIMP5, D1_ALQIMP5, D1_VALIMP5, " 																				+ CRLF
-	cQuery += " FT_BASEPIS, FT_ALIQPIS, FT_VALPIS, FT_ALIQPS3, FT_VALPS3, "															+ CRLF
-	cQuery += " FT_BASECOF, FT_ALIQCOF, FT_VALCOF, FT_DIFAL, FT_BASECF3, FT_ALIQCF3, FT_VALCF3, FT_BASEPS3, "						+ CRLF
-	cQuery += " FT_BASEIRR, FT_ALIQIRR, FT_VALIRR, F3_OUTRIPI, F3_ISENIPI, F3_OUTRICM, F3_ISENICM, " 								+ CRLF
-	cQuery += " FT_BASECSL, FT_ALIQCSL, FT_VALCSL, D1_UM, D1_QUANT, D1_CHASSI, "													+ CRLF
-	cQuery += " FT_BASEINS, FT_ALIQINS, D1_ABATINS, D1_AVLINSS, FT_VALINS, C7_NUM, FT_FORMUL, "										+ CRLF
-	cQuery += " D1_BASEISS, D1_ALIQISS, D1_ABATISS, D1_ABATMAT, D1_VALISS, FT_CODBCC, FT_INDNTFR, "									+ CRLF
-	cQuery += " D1_VALFRE, D1_DESPESA, D1_CUSTO, D1_SEGURO, D1_VALACRS, D1_II, FT_ICMSCOM, D1_TNATREC, D1_CONHEC,  "				+ CRLF
-	cQuery += " D1_PESO, FT_MVALPIS, FT_MVALCOF, W6_DTREG_D, W6_DI_NUM, YD_PER_II, VRK_OPCION, W9_TX_FOB, D1_CHASSI "							+ CRLF
+	cQuery += " GROUP BY 	D1_FILIAL , D1_COD    , D1_DOC    , D1_SERIE  , D1_TES    , D1_CF     , D1_FORNECE, D1_LOJA   , " + CRLF
+	cQuery += " 			D1_ITEM   , D1_CONTA  , D1_ITEMCTA, D1_NFORI  , D1_SERIORI, D1_VUNIT  , D1_TOTAL  , D1_CONHEC , " + CRLF
+	cQuery += " 			D1_BASIMP6, D1_ALQIMP6, D1_VALIMP6, D1_BASIMP5, D1_ALQIMP5, D1_VALIMP5, FT_BRETCOF, D1_ABATINS, " + CRLF
+	cQuery += " 			D1_AVLINSS, D1_PESO   , D1_EMISSAO, D1_DTDIGIT, D1_DESC   , D1_DESCZFP, D1_DESCZFC, D1_VALISS , " + CRLF
+	cQuery += " 			D1_VALFRE , D1_DESPESA, D1_CUSTO  , D1_SEGURO , D1_VALACRS, D1_II     , FT_ICMSCOM, D1_TNATREC, " + CRLF
+	cQuery += " 			D1_BASEISS, D1_ALIQISS, D1_ABATISS, D1_ABATMAT, D1_UM     , D1_QUANT  , D1_CHASSI, " + CRLF
+		
+	cQuery += " 			F1_UFORITR, F1_MUORITR, F1_UFDESTR, F1_MUDESTR, F1_ESPECIE, F1_CODNFE , F1_MENNOTA, F1_STATUS,  " + CRLF
+	cQuery += "				F1_DOC, F1_SERIE, F1_TIPO, " + CRLF
+	
+	cQuery += " 			FT_VALCONT, FT_DESCONT, FT_MVALPIS, FT_MVALCOF, FT_CODBCC , FT_INDNTFR, FT_BASEINS, FT_ALIQINS, " + CRLF
+	cQuery += " 			FT_BASEICM, FT_ALIQICM, FT_VALICM , FT_CTIPI  , FT_CSTPIS , FT_CSTCOF , FT_VALINS , FT_CHVNFE , " + CRLF
+	cQuery += " 			FT_BASEIPI, FT_ALIQIPI, FT_VALIPI , FT_ARETPIS, FT_ARETCOF, FT_VRETPIS, FT_VRETCOF, FT_BRETPIS, " + CRLF
+	cQuery += " 			FT_BASEPIS, FT_ALIQPIS, FT_VALPIS , FT_ALIQPS3, FT_VALPS3 , FT_CLASFIS, FT_BASERET, FT_ICMSRET, " + CRLF
+	cQuery += " 			FT_BASECOF, FT_ALIQCOF, FT_VALCOF , FT_DIFAL  , FT_BASECF3, FT_ALIQCF3, FT_VALCF3 , FT_BASEPS3, " + CRLF
+	cQuery += " 			FT_BASEIRR, FT_ALIQIRR, FT_VALIRR , FT_BASECSL, FT_ALIQCSL, FT_VALCSL ," + CRLF
+	
+	cQuery += " 			F3_OUTRIPI, F3_ISENIPI, F3_OUTRICM, F3_ISENICM, " + CRLF
+	
+	cQuery += " 			C7_NUM    , FT_FORMUL , " + CRLF
+	
+	cQuery += " 			B1_DESC   , B1_XDESCL1, B1_GRUPO  , B1_POSIPI , B1_CEST   , B1_ORIGEM , B1_EX_NCM ,B1_EX_NBM, " + CRLF
+	
+	cQuery += " 			F4_FINALID, F4_TEXTO  ,F4_ICM     , F4_IPI    , F4_CREDICM, F4_CREDIPI, F4_DUPLIC ,W6_DTREG_D," + CRLF
+	
+	cQuery += "				W6_DI_NUM , VRK_OPCION, W9_TX_FOB  " + CRLF
 
 	cQuery += " ORDER BY SD1.D1_FILIAL, SD1.D1_EMISSAO, SD1.D1_DOC, SD1.D1_SERIE, SD1.D1_ITEM, SD1.D1_FORNECE, SD1.D1_LOJA "		+ CRLF
 

--- a/SIGAFIS/Relatorio/ZFISR001.prw
+++ b/SIGAFIS/Relatorio/ZFISR001.prw
@@ -1577,9 +1577,9 @@ Static Function zRel0002(cArquivo)
 														nTotal,;    //--Valor Total Item
 														(cAliasTRB)->D2_CF,;         //--Cfop
 														(cAliasTRB)->FT_VALCONT,;    //--Valor Contábil
-														iif( Alltrim((cAliasTRB)->F2_ESPECIE) <> "RPS", (cAliasTRB)->FT_BASEICM , 0),;    //--Base ICMS
-														iif( Alltrim((cAliasTRB)->F2_ESPECIE) <> "RPS", (cAliasTRB)->FT_ALIQICM , 0),;    //--Aliq. ICMS
-														iif( Alltrim((cAliasTRB)->F2_ESPECIE) <> "RPS", (cAliasTRB)->FT_VALICM  , 0), ;     //--Valor ICMS
+														iif( Alltrim((cAliasTRB)->F2_ESPECIE) <> "RPS", (cAliasTRB)->FT_BASEICM , 0 ),;    //--Base ICMS
+														iif( Alltrim((cAliasTRB)->F2_ESPECIE) <> "RPS", (cAliasTRB)->FT_ALIQICM , 0 ),;    //--Aliq. ICMS
+														iif( Alltrim((cAliasTRB)->F2_ESPECIE) <> "RPS", (cAliasTRB)->FT_VALICM  , 0 ),;     //--Valor ICMS
 														(cAliasTRB)->C6_XVLCOM,;     //--Comissão
 														(cAliasTRB)->FT_BASEIPI,;    //--Base IPI
 														(cAliasTRB)->FT_ALIQIPI,;    //--Aliq. IPI

--- a/SIGAFIS/Relatorio/ZFISR003.prw
+++ b/SIGAFIS/Relatorio/ZFISR003.prw
@@ -552,40 +552,50 @@ Static Function ZTmpRadio1()
 		(cAliasTMP)->(DbCloseArea())
 	EndIf
 
-	cQuery += " SELECT 	D1_FILIAL, D1_COD, D1_DOC, D1_SERIE, D1_TES, D1_CF, D1_FORNECE, D1_LOJA, D1_EMISSAO, D1_DTDIGIT, " 			+ CRLF
-	cQuery += " D1_ITEM, F4_FINALID, F4_TEXTO, FT_CTIPI, FT_CSTPIS, FT_CSTCOF, F4_ICM, F4_IPI, F4_CREDICM, F4_CREDIPI, F4_DUPLIC, "	+ CRLF
-	cQuery += "	B1_DESC, B1_XDESCL1, B1_GRUPO, B1_POSIPI, B1_CEST, B1_ORIGEM, B1_EX_NCM, B1_EX_NBM ,"								  			+ CRLF
-	cQuery += "	F1_ESPECIE, F1_CODNFE, F1_MENNOTA, F1_DOC, F1_SERIE, F1_STATUS, F1_TIPO, FT_CHVNFE, "								+ CRLF
-	cQuery += " FT_VALCONT, FT_DESCONT, D1_CONTA, D1_ITEMCTA, D1_NFORI, D1_SERIORI, D1_VUNIT, D1_TOTAL, "							+ CRLF
-	cQuery += " CASE " + CRLF
-    cQuery += "     WHEN F1_DESCONT > 0 THEN " + CRLF
-    cQuery += "         ROUND(((D1_TOTAL / F1_DESCONT) * F1_DESCONT),2)" + CRLF
-    cQuery += "     WHEN F1_DESCONT = 0 THEN " + CRLF
-    cQuery += "         F1_DESCONT " + CRLF
-    cQuery += " END AS F1_DESCONT, " + CRLF
-    cQuery += " FT_CLASFIS, FT_BASERET, FT_ICMSRET, D1_DESCZFP, D1_DESCZFC,"+ CRLF
-    cQuery += " F1_UFORITR, F1_MUORITR, F1_UFDESTR, F1_MUDESTR,  "																	+ CRLF
-	cQuery += " FT_BASEICM, FT_ALIQICM, FT_VALICM, FT_BRETPIS, FT_ARETPIS, FT_VRETPIS, FT_BRETCOF, FT_ARETCOF, FT_VRETCOF, " 		+ CRLF
-	cQuery += " FT_BASEIPI, FT_ALIQIPI, FT_VALIPI, " 																				+ CRLF
-	cQuery += " D1_BASIMP6, D1_ALQIMP6, D1_VALIMP6, " 																				+ CRLF
-	cQuery += " D1_BASIMP5, D1_ALQIMP5, D1_VALIMP5, "													                            + CRLF
-	cQuery += " FT_BASEPIS, FT_ALIQPIS, FT_VALPIS, FT_ALIQPS3, FT_VALPS3, "															+ CRLF
-	cQuery += " FT_BASECOF, FT_ALIQCOF, FT_VALCOF, FT_DIFAL, FT_BASECF3, FT_ALIQCF3, FT_VALCF3, FT_BASEPS3, "						+ CRLF
-	cQuery += " FT_BASEIRR, FT_ALIQIRR, FT_VALIRR, F3_OUTRIPI, F3_ISENIPI, F3_OUTRICM, F3_ISENICM, " 								+ CRLF
-	cQuery += " FT_BASECSL, FT_ALIQCSL, FT_VALCSL, D1_UM, D1_QUANT, D1_CHASSI, "													+ CRLF
-	cQuery += " FT_BASEINS, FT_ALIQINS, D1_ABATINS, D1_AVLINSS, FT_VALINS, C7_NUM, FT_FORMUL, "										+ CRLF
-	cQuery += " D1_BASEISS, D1_ALIQISS, D1_ABATISS, D1_ABATMAT, D1_VALISS, FT_CODBCC, FT_INDNTFR, "									+ CRLF
-	cQuery += " D1_VALFRE, D1_DESPESA, D1_CUSTO, D1_SEGURO, D1_VALACRS, D1_II, FT_ICMSCOM, D1_TNATREC, D1_CONHEC, "					+ CRLF
-	cQuery += " D1_PESO, FT_MVALPIS, FT_MVALCOF, W6_DTREG_D, W6_DI_NUM, YD_PER_II, VRK_OPCION, W9_TX_FOB " 					        + CRLF
+	cQuery += " SELECT 	D1_FILIAL , D1_COD    , D1_DOC    , D1_SERIE  , D1_TES   , D1_CF     , D1_FORNECE, D1_LOJA  , D1_EMISSAO, D1_DTDIGIT, "	+ CRLF
+	cQuery += "         D1_ITEM   , F4_FINALID, F4_TEXTO  , FT_CTIPI  , FT_CSTPIS, FT_CSTCOF , F4_ICM    , F4_IPI   , F4_CREDICM, F4_CREDIPI, F4_DUPLIC, " + CRLF
+	cQuery += "	        B1_DESC   , B1_XDESCL1, B1_GRUPO  , B1_POSIPI , B1_CEST  , B1_ORIGEM , B1_EX_NCM , B1_EX_NBM, " + CRLF
+	cQuery += "	        F1_ESPECIE, F1_CODNFE , F1_MENNOTA, F1_DOC    , F1_SERIE , F1_STATUS , F1_TIPO   , FT_CHVNFE, " + CRLF
+	cQuery += "         FT_VALCONT, FT_DESCONT, D1_CONTA  , D1_ITEMCTA, D1_NFORI , D1_SERIORI, D1_VUNIT  , D1_TOTAL , " + CRLF
+	cQuery += "         CASE " + CRLF
+    cQuery += "             WHEN F1_DESCONT > 0 THEN " + CRLF
+    cQuery += "                 ROUND(((D1_TOTAL / F1_DESCONT) * F1_DESCONT),2)" + CRLF
+    cQuery += "             WHEN F1_DESCONT = 0 THEN " + CRLF
+    cQuery += "                 F1_DESCONT " + CRLF
+    cQuery += "         END AS F1_DESCONT, " + CRLF
+    cQuery += "         FT_CLASFIS, FT_BASERET, FT_ICMSRET, D1_DESCZFP, D1_DESCZFC," + CRLF
+    cQuery += "         F1_UFORITR, F1_MUORITR, F1_UFDESTR, F1_MUDESTR, " + CRLF
+	cQuery += "         FT_BASEICM, FT_ALIQICM, FT_VALICM , FT_BRETPIS, FT_ARETPIS, FT_VRETPIS, FT_BRETCOF, FT_ARETCOF, FT_VRETCOF, " + CRLF
+	cQuery += "         FT_BASEIPI, FT_ALIQIPI, FT_VALIPI , " + CRLF
+	cQuery += "         D1_BASIMP6, D1_ALQIMP6, D1_VALIMP6, D1_BASIMP5, D1_ALQIMP5, D1_VALIMP5, " + CRLF
+	cQuery += "         FT_BASEPIS, FT_ALIQPIS, FT_VALPIS , FT_ALIQPS3, FT_VALPS3 , " + CRLF
+	cQuery += "         FT_BASECOF, FT_ALIQCOF, FT_VALCOF , FT_DIFAL  , FT_BASECF3, FT_ALIQCF3, FT_VALCF3 , FT_BASEPS3, " + CRLF
+	cQuery += "         FT_BASEIRR, FT_ALIQIRR, FT_VALIRR , F3_OUTRIPI, F3_ISENIPI, F3_OUTRICM, F3_ISENICM, " + CRLF
+	cQuery += "         FT_BASECSL, FT_ALIQCSL, FT_VALCSL , D1_UM     , D1_QUANT  , D1_CHASSI , " + CRLF
+	cQuery += "         FT_BASEINS, FT_ALIQINS, D1_ABATINS, D1_AVLINSS, FT_VALINS , C7_NUM    , FT_FORMUL , " + CRLF
+	cQuery += "         D1_BASEISS, D1_ALIQISS, D1_ABATISS, D1_ABATMAT, D1_VALISS , FT_CODBCC , FT_INDNTFR, " + CRLF
+	cQuery += "         D1_VALFRE , D1_DESPESA, D1_CUSTO  , D1_SEGURO , D1_VALACRS, D1_II     , FT_ICMSCOM, D1_TNATREC, D1_CONHEC, " + CRLF
+	cQuery += "         D1_PESO   , FT_MVALPIS, FT_MVALCOF, W6_DTREG_D, W6_DI_NUM , " + CRLF
+
+	cQuery += "        ( Select SYD.YD_PER_II from " + RetSqlName("SYD") + " SYD " + CRLF
+ 	cQuery += "	          where SYD.YD_FILIAL  = '" +  FWxFilial('SYD') + "' " + CRLF
+	cQuery += "	        	AND SYD.YD_TEC     = SB1.B1_POSIPI " + CRLF
+	cQuery += "	        	AND SYD.YD_EX_NCM  = SB1.B1_EX_NCM " + CRLF
+	cQuery += "	        	AND SYD.YD_EX_NBM  = SB1.B1_EX_NBM " + CRLF
+    cQuery += "	        	AND SYD.D_E_L_E_T_ = ' ' " + CRLF
+    cQuery += "	        	AND     ROWNUM     = 1 " + CRLF
+    cQuery += "	        	) as YD_PER_II,  " + CRLF
+
+    cQuery += "         VRK_OPCION, W9_TX_FOB " + CRLF
 
 	cQuery += " FROM " + RetSQLName('SD1') + " SD1 "																				+ CRLF
 
 	cQuery += " INNER JOIN " + RetSQLName('SF1') + " SF1 "			 																+ CRLF
-	cQuery += " 	ON SF1.F1_FILIAL = '" + FWxFilial('SF1') + "' "																    + CRLF	
-	cQuery += " 	AND SF1.F1_DOC = SD1.D1_DOC " 																					+ CRLF
-	cQuery += " 	AND SF1.F1_SERIE = SD1.D1_SERIE " 																				+ CRLF
+	cQuery += " 	ON  SF1.F1_FILIAL  = '" + FWxFilial('SF1') + "' "																    + CRLF	
+	cQuery += " 	AND SF1.F1_DOC     = SD1.D1_DOC " 																					+ CRLF
+	cQuery += " 	AND SF1.F1_SERIE   = SD1.D1_SERIE " 																				+ CRLF
 	cQuery += " 	AND SF1.F1_FORNECE = SD1.D1_FORNECE " 																			+ CRLF
-	cQuery += " 	AND SF1.F1_LOJA = SD1.D1_LOJA " 																				+ CRLF
+	cQuery += " 	AND SF1.F1_LOJA    = SD1.D1_LOJA " 																				+ CRLF
 	cQuery += " 	AND SF1.F1_ESPECIE BETWEEN '" +MV_PAR03+ "' AND '" +MV_PAR04+ "' " 												+ CRLF
 	cQuery += " 	AND SF1.D_E_L_E_T_ = ' ' " 																						+ CRLF	
 
@@ -594,8 +604,8 @@ Static Function ZTmpRadio1()
 	EndIf 
 
 	cQuery += " INNER JOIN " + RetSQLName("SB1") + " SB1  " 																		+ CRLF
-	cQuery += " 	ON SB1.B1_FILIAL = '" + FWxFilial('SB1') + "'  "															    + CRLF
-	cQuery += "		AND SB1.B1_COD = SD1.D1_COD  "	 																				+ CRLF
+	cQuery += " 	ON  SB1.B1_FILIAL  = '" + FWxFilial('SB1') + "'  "															    + CRLF
+	cQuery += "		AND SB1.B1_COD     = SD1.D1_COD  "	 																				+ CRLF
 	cQuery += "     AND SB1.D_E_L_E_T_ = ' '   " 																					+ CRLF
 	
 	If !Empty( MV_PAR20 )
@@ -607,74 +617,74 @@ Static Function ZTmpRadio1()
 	EndIf
 
 	cQuery += " INNER JOIN " + RetSQLName("SF4") + " SF4 " 																			+ CRLF
-	cQuery += " 	ON SF4.F4_FILIAL = '" + FWxFilial('SF4') + "'  "															    + CRLF
-	cQuery += "		AND SF4.F4_CODIGO = SD1.D1_TES  "	 																			+ CRLF
+	cQuery += " 	ON  SF4.F4_FILIAL  = '" + FWxFilial('SF4') + "'  "															    + CRLF
+	cQuery += "		AND SF4.F4_CODIGO  = SD1.D1_TES  "	 																			+ CRLF
 	cQuery += "     AND SF4.D_E_L_E_T_ = ' '   " 																					+ CRLF
 
 	cQuery += " LEFT JOIN " + RetSQLName("SW6") + " SW6  " 																			+ CRLF
-	cQuery += " 	ON SW6.W6_FILIAL = '" + FWxFilial('SW6') + "' "																    + CRLF
-	cQuery += "		AND SW6.W6_HAWB = SD1.D1_CONHEC  "	 																			+ CRLF
+	cQuery += " 	ON  SW6.W6_FILIAL  = '" + FWxFilial('SW6') + "' "																    + CRLF
+	cQuery += "		AND SW6.W6_HAWB    = SD1.D1_CONHEC  "	 																			+ CRLF
 	cQuery += "     AND SW6.D_E_L_E_T_ = ' '   " 																					+ CRLF
 
     cQuery += " LEFT JOIN " + RetSQLName("SW9") + " SW9  " 																			+ CRLF
-	cQuery += " 	ON SW9.W9_FILIAL = '" + FWxFilial('SW9') + "' "																	+ CRLF
-	cQuery += "		AND SW9.W9_HAWB = SD1.D1_CONHEC  "	 																			+ CRLF
+	cQuery += " 	ON  SW9.W9_FILIAL  = '" + FWxFilial('SW9') + "' "																	+ CRLF
+	cQuery += "		AND SW9.W9_HAWB    = SD1.D1_CONHEC  "	 																			+ CRLF
 	cQuery += "     AND SW9.D_E_L_E_T_ = ' '   " 																					+ CRLF
-
+/*
 	cQuery += " LEFT JOIN " + RetSQLName("SYD") + " SYD  " 																			+ CRLF
 	cQuery += " 	ON SYD.YD_FILIAL = '" + FWxFilial('SYD') + "' "																    + CRLF
     cQuery += "		AND SYD.YD_TEC = SB1.B1_POSIPI "	 																			+ CRLF
 	cQuery += "		AND SYD.YD_EX_NCM = SB1.B1_EX_NCM  "	 																		+ CRLF
 	cQuery += "		AND SYD.YD_EX_NBM = SB1.B1_EX_NBM  "	 																		+ CRLF
 	cQuery += "     AND SYD.D_E_L_E_T_ = ' '   " 																					+ CRLF
-
+*/
 	cQuery += " LEFT JOIN " + RetSQLName("VVF") + " VVF "																			+ CRLF
-	cQuery += "		ON VVF.VVF_FILIAL = '" + FWxFilial('VVF') + "' "															    + CRLF
+	cQuery += "		ON  VVF.VVF_FILIAL = '" + FWxFilial('VVF') + "' "															    + CRLF
 	cQuery += " 	AND VVF.VVF_NUMNFI = SF1.F1_DOC "																				+ CRLF
 	cQuery += " 	AND VVF.VVF_SERNFI = SF1.F1_SERIE " 																			+ CRLF
 	cQuery += " 	AND VVF.VVF_CODFOR = SF1.F1_FORNECE " 																			+ CRLF
-	cQuery += " 	AND VVF.VVF_LOJA = SF1.F1_LOJA " 																				+ CRLF
+	cQuery += " 	AND VVF.VVF_LOJA   = SF1.F1_LOJA " 																				+ CRLF
 	cQuery += " 	AND VVF.D_E_L_E_T_ = ' ' "																	 					+ CRLF
 
 	cQuery += " LEFT JOIN " + RetSQLName("SC7") + " SC7 "																			+ CRLF
-	cQuery += " 	ON SC7.C7_FILIAL = '" + FWxFilial('SC7') + "' "																    + CRLF
-	cQuery += "		AND SC7.C7_NUM = SD1.D1_PEDIDO "																				+ CRLF
-	cQuery += "		AND SC7.C7_ITEM = SD1.D1_ITEMPC "												 								+ CRLF
+	cQuery += " 	ON  SC7.C7_FILIAL  = '" + FWxFilial('SC7') + "' "																    + CRLF
+	cQuery += "		AND SC7.C7_NUM     = SD1.D1_PEDIDO "																				+ CRLF
+	cQuery += "		AND SC7.C7_ITEM    = SD1.D1_ITEMPC "												 								+ CRLF
 	cQuery += "		AND SC7.D_E_L_E_T_ = ' ' "																						+ CRLF
 	
 	cQuery += " LEFT JOIN " + RetSQLName("VRK") + " VRK "																			+ CRLF
-	cQuery += " 	ON VRK.VRK_FILIAL = '" + FWxFilial('VRK') + "' "  															    + CRLF
+	cQuery += " 	ON  VRK.VRK_FILIAL = '" + FWxFilial('VRK') + "' "  															    + CRLF
 	cQuery += "		AND VRK.VRK_PEDIDO = SD1.D1_PEDIDO	"																			+ CRLF
     cQuery += "     AND VRK.VRK_ITEPED = SD1.D1_ITEMPC	"																			+ CRLF
 	cQuery += "     AND VRK.D_E_L_E_T_ = ' '   " 																					+ CRLF
 
 	cQuery += " INNER JOIN " + RetSQLName("SFT") + " SFT " 																			+ CRLF
-	cQuery += "		ON SFT.FT_FILIAL = '" + FWxFilial('SFT') + "' "																    + CRLF
+	cQuery += "		ON  SFT.FT_FILIAL  = '" + FWxFilial('SFT') + "' "																    + CRLF
 	cQuery += "		AND SFT.FT_TIPOMOV = 'E' "																						+ CRLF
-	cQuery += "		AND SFT.FT_SERIE = SD1.D1_SERIE "																				+ CRLF
+	cQuery += "		AND SFT.FT_SERIE   = SD1.D1_SERIE "																				+ CRLF
 	cQuery += " 	AND SFT.FT_NFISCAL = SD1.D1_DOC "																				+ CRLF
 	cQuery += "		AND SFT.FT_CLIEFOR = SD1.D1_FORNECE " 																			+ CRLF
-	cQuery += "		AND SFT.FT_LOJA = SD1.D1_LOJA " 																				+ CRLF
-	cQuery += "		AND SFT.FT_ITEM = SD1.D1_ITEM " 																				+ CRLF
+	cQuery += "		AND SFT.FT_LOJA    = SD1.D1_LOJA " 																				+ CRLF
+	cQuery += "		AND SFT.FT_ITEM    = SD1.D1_ITEM " 																				+ CRLF
 	cQuery += "		AND SFT.FT_PRODUTO = SD1.D1_COD " 																				+ CRLF	
 	cQuery += "		AND SFT.D_E_L_E_T_ = ' ' "																						+ CRLF
 
 	cQuery += " INNER JOIN " + RetSQLName("SF3") + " SF3 " 																			+ CRLF
-	cQuery += "		ON SF3.F3_FILIAL = '" + FWxFilial('SF3') + "' "																    + CRLF
-	cQuery += "		AND SF3.F3_SERIE = SFT.FT_SERIE "																				+ CRLF
+	cQuery += "		ON  SF3.F3_FILIAL  = '" + FWxFilial('SF3') + "' "																    + CRLF
+	cQuery += "		AND SF3.F3_SERIE   = SFT.FT_SERIE "																				+ CRLF
 	cQuery += "		AND SF3.F3_NFISCAL = SFT.FT_NFISCAL "																			+ CRLF
 	cQuery += " 	AND SF3.F3_CLIEFOR = SFT.FT_CLIEFOR "																			+ CRLF
-	cQuery += "		AND SF3.F3_LOJA = SFT.FT_LOJA " 																				+ CRLF
+	cQuery += "		AND SF3.F3_LOJA    = SFT.FT_LOJA " 																				+ CRLF
 	cQuery += "		AND SF3.F3_IDENTFT = SFT.FT_IDENTF3 " 																			+ CRLF
 	cQuery += "		AND SF3.D_E_L_E_T_ = ' ' "																						+ CRLF
 
-	cQuery += " WHERE SD1.D1_FILIAL BETWEEN '" + MV_PAR01 + "' AND '" + MV_PAR02 + "' " 											+ CRLF
-	cQuery += " 	AND SD1.D1_DOC BETWEEN '" + MV_PAR05 + "' AND '" + MV_PAR06 + "' " 												+ CRLF
-	cQuery += " 	AND SD1.D1_SERIE BETWEEN '" + MV_PAR07 + "' AND '" + MV_PAR08 + "' " 											+ CRLF
-	cQuery += " 	AND SD1.D1_FORNECE BETWEEN '" + MV_PAR09 + "' AND '" + MV_PAR10 + "' " 											+ CRLF
+	cQuery += " WHERE   SD1.D1_FILIAL  BETWEEN '" +       MV_PAR01   + "' AND '" +       MV_PAR02   + "' " 											+ CRLF
+	cQuery += " 	AND SD1.D1_DOC     BETWEEN '" +       MV_PAR05   + "' AND '" +       MV_PAR06   + "' " 												+ CRLF
+	cQuery += " 	AND SD1.D1_SERIE   BETWEEN '" +       MV_PAR07   + "' AND '" +       MV_PAR08   + "' " 											+ CRLF
+	cQuery += " 	AND SD1.D1_FORNECE BETWEEN '" +       MV_PAR09   + "' AND '" +       MV_PAR10   + "' " 											+ CRLF
 	cQuery += " 	AND SD1.D1_DTDIGIT BETWEEN '" + DToS( MV_PAR11 ) + "' AND '" + DToS( MV_PAR12 ) + "' " 							+ CRLF
 	cQuery += " 	AND SD1.D1_EMISSAO BETWEEN '" + DToS( MV_PAR13 ) + "' AND '" + DToS( MV_PAR14 ) + "' " 							+ CRLF
-	cQuery += " 	AND SD1.D1_COD BETWEEN '" + MV_PAR15 + "' AND '" + MV_PAR16 + "' " 												+ CRLF
+	cQuery += " 	AND SD1.D1_COD     BETWEEN '" +       MV_PAR15   + "' AND '" +       MV_PAR16   + "' " 												+ CRLF
 	cQuery += " 	AND SD1.D_E_L_E_T_ = ' ' "	 																					+ CRLF
 
 	If !Empty( MV_PAR17 )
@@ -689,32 +699,32 @@ Static Function ZTmpRadio1()
        cQuery += " 	AND SD1.D1_CHASSI BETWEEN '" + MV_PAR23 + "' AND '" + MV_PAR24 + "' " 
     EndIf
     
-	cQuery += " GROUP BY 	D1_FILIAL, D1_COD, D1_DOC, D1_SERIE, D1_TES, D1_CF, D1_FORNECE, D1_LOJA, D1_EMISSAO, D1_DTDIGIT, " 		+ CRLF
-	cQuery += " D1_ITEM, F4_FINALID, F4_TEXTO, FT_CTIPI, FT_CSTPIS, FT_CSTCOF,  F4_ICM, F4_IPI, F4_CREDICM, F4_CREDIPI, F4_DUPLIC, "+ CRLF
-	cQuery += " B1_DESC, B1_XDESCL1, B1_GRUPO, B1_POSIPI, B1_CEST, B1_ORIGEM, B1_EX_NCM, B1_EX_NBM ,"											+ CRLF
-	cQuery += "	F1_ESPECIE, F1_CODNFE, F1_MENNOTA, F1_DOC, F1_SERIE, F1_STATUS, F1_TIPO, FT_CHVNFE,"								+ CRLF
-	cQuery += " FT_VALCONT, FT_DESCONT, D1_CONTA, D1_ITEMCTA, D1_NFORI, D1_SERIORI, D1_VUNIT, D1_TOTAL, "							+ CRLF
-    cQuery += " CASE "
-    cQuery += "     WHEN F1_DESCONT > 0 THEN "
-    cQuery += "         ROUND(((D1_TOTAL / F1_DESCONT) * F1_DESCONT),2)"
-    cQuery += "     WHEN F1_DESCONT = 0 THEN "
-    cQuery += "         F1_DESCONT "
-    cQuery += " END  "
-    cQuery += " , FT_CLASFIS, FT_BASERET, FT_ICMSRET, D1_DESCZFP, D1_DESCZFC,  "				+ CRLF
+	cQuery += " GROUP BY 	D1_FILIAL , D1_COD    , D1_DOC    , D1_SERIE  , D1_TES    , D1_CF     , D1_FORNECE, D1_LOJA   , " + CRLF
+	cQuery += "             D1_EMISSAO, D1_DTDIGIT, D1_CONTA  , D1_ITEMCTA, D1_NFORI  , D1_SERIORI, D1_VUNIT  , D1_TOTAL  , " + CRLF
+	cQuery += "             D1_BASIMP6, D1_ALQIMP6, D1_VALIMP6, D1_UM     , D1_QUANT  , D1_CHASSI , D1_DESCZFP, D1_DESCZFC, " + CRLF
+	cQuery += "             D1_BASIMP5, D1_ALQIMP5, D1_VALIMP5, D1_PESO   , D1_ABATINS, D1_AVLINSS, D1_ITEM   , D1_SEGURO , " + CRLF
+	cQuery += "             D1_BASEISS, D1_ALIQISS, D1_ABATISS, D1_ABATMAT, D1_VALISS , FT_CODBCC , FT_INDNTFR, D1_CONHEC , " + CRLF
+	cQuery += "             D1_VALFRE , D1_DESPESA, D1_CUSTO  , D1_VALACRS, D1_II     , D1_TNATREC,  " + CRLF
 	
-    cQuery += " F1_UFORITR, F1_MUORITR, F1_UFDESTR, F1_MUDESTR,  "																	+ CRLF
-	cQuery += " FT_BASEICM, FT_ALIQICM, FT_VALICM, FT_BRETPIS, FT_ARETPIS, FT_VRETPIS, FT_BRETCOF, FT_ARETCOF, FT_VRETCOF, "        + CRLF
-	cQuery += " FT_BASEIPI, FT_ALIQIPI, FT_VALIPI, " 																				+ CRLF
-	cQuery += " D1_BASIMP6, D1_ALQIMP6, D1_VALIMP6, " 																				+ CRLF
-	cQuery += " D1_BASIMP5, D1_ALQIMP5, D1_VALIMP5, " 																				+ CRLF
-	cQuery += " FT_BASEPIS, FT_ALIQPIS, FT_VALPIS, FT_ALIQPS3, FT_VALPS3, "															+ CRLF
-	cQuery += " FT_BASECOF, FT_ALIQCOF, FT_VALCOF, FT_DIFAL, FT_BASECF3, FT_ALIQCF3, FT_VALCF3, FT_BASEPS3, "						+ CRLF
-	cQuery += " FT_BASEIRR, FT_ALIQIRR, FT_VALIRR, F3_OUTRIPI, F3_ISENIPI, F3_OUTRICM, F3_ISENICM, " 								+ CRLF
-	cQuery += " FT_BASECSL, FT_ALIQCSL, FT_VALCSL, D1_UM, D1_QUANT, D1_CHASSI, "													+ CRLF
-	cQuery += " FT_BASEINS, FT_ALIQINS, D1_ABATINS, D1_AVLINSS, FT_VALINS, C7_NUM, FT_FORMUL, "										+ CRLF
-	cQuery += " D1_BASEISS, D1_ALIQISS, D1_ABATISS, D1_ABATMAT, D1_VALISS, FT_CODBCC, FT_INDNTFR, "									+ CRLF
-	cQuery += " D1_VALFRE, D1_DESPESA, D1_CUSTO, D1_SEGURO, D1_VALACRS, D1_II, FT_ICMSCOM, D1_TNATREC, D1_CONHEC,  "				+ CRLF
-	cQuery += " D1_PESO, FT_MVALPIS, FT_MVALCOF, W6_DTREG_D, W6_DI_NUM, YD_PER_II, VRK_OPCION, W9_TX_FOB "                          + CRLF
+    cQuery += "	            F1_ESPECIE, F1_CODNFE, F1_MENNOTA, F1_DOC, F1_SERIE, F1_STATUS, F1_TIPO," + CRLF
+    cQuery += "             F1_UFORITR, F1_MUORITR, F1_UFDESTR, F1_MUDESTR,  " + CRLF
+    cQuery += "             CASE "  + CRLF
+    cQuery += "                 WHEN F1_DESCONT > 0 THEN "  + CRLF
+    cQuery += "                     ROUND(((D1_TOTAL / F1_DESCONT) * F1_DESCONT),2)"  + CRLF
+    cQuery += "                 WHEN F1_DESCONT = 0 THEN "  + CRLF
+    cQuery += "                     F1_DESCONT "  + CRLF
+    cQuery += "             END,  "  + CRLF
+	
+    cQuery += "             F3_OUTRIPI, F3_ISENIPI, F3_OUTRICM, F3_ISENICM, "
+    cQuery += "             FT_CLASFIS, FT_BASERET, FT_ICMSRET, FT_VRETPIS, FT_BRETCOF, FT_CHVNFE , FT_FORMUL , FT_MVALPIS , " + CRLF
+	cQuery += "             FT_BASEICM, FT_ALIQICM, FT_VALICM , FT_BRETPIS, FT_ARETPIS, FT_ARETCOF, FT_VRETCOF, FT_DESCONT , " + CRLF
+	cQuery += "             FT_BASEIPI, FT_ALIQIPI, FT_VALIPI , FT_CTIPI  , FT_CSTPIS , FT_CSTCOF , FT_VALINS , FT_VALCONT , " + CRLF
+	cQuery += "             FT_BASEPIS, FT_ALIQPIS, FT_VALPIS , FT_ALIQPS3, FT_VALPS3 , FT_ICMSCOM, FT_MVALCOF, FT_ALIQINS , " + CRLF
+	cQuery += "             FT_BASECOF, FT_ALIQCOF, FT_VALCOF , FT_DIFAL  , FT_BASECF3, FT_ALIQCF3, FT_VALCF3 , FT_BASEPS3 , " + CRLF
+	cQuery += "             FT_BASEIRR, FT_ALIQIRR, FT_VALIRR , FT_BASECSL, FT_ALIQCSL, FT_VALCSL , FT_BASEINS, " + CRLF
+	cQuery += "             F4_FINALID, F4_TEXTO  , F4_ICM    , F4_IPI    , F4_CREDICM, F4_CREDIPI, F4_DUPLIC , " + CRLF
+    cQuery += "             W6_DTREG_D, W6_DI_NUM , VRK_OPCION, W9_TX_FOB , C7_NUM, " + CRLF
+	cQuery += "             B1_DESC   , B1_XDESCL1, B1_GRUPO, B1_POSIPI   , B1_CEST   , B1_ORIGEM , B1_EX_NCM , B1_EX_NBM " + CRLF
 
 	cQuery += " ORDER BY SD1.D1_FILIAL, SD1.D1_EMISSAO, SD1.D1_DOC, SD1.D1_SERIE, SD1.D1_ITEM, SD1.D1_FORNECE, SD1.D1_LOJA "		+ CRLF
 

--- a/SIGAFIS/Relatorio/ZFISR008.prw
+++ b/SIGAFIS/Relatorio/ZFISR008.prw
@@ -163,7 +163,20 @@ Static Function zRel001B(cArquivo)
 	cQuery += " FT_BASEINS, FT_ALIQINS, D1_ABATINS, D1_AVLINSS, FT_VALINS, C7_NUM, FT_FORMUL, "										+ CRLF
 	cQuery += " D1_BASEISS, D1_ALIQISS, D1_ABATISS, D1_ABATMAT, D1_VALISS, FT_CODBCC, FT_INDNTFR, "									+ CRLF
 	cQuery += " D1_VALFRE, D1_DESPESA, D1_CUSTO, D1_SEGURO, D1_VALACRS, D1_II, FT_ICMSCOM, D1_TNATREC, D1_CONHEC, "					+ CRLF
-	cQuery += " D1_PESO, FT_MVALPIS, FT_MVALCOF, W6_DTREG_D, W6_DI_NUM, YD_PER_II, VRK_OPCION, W9_TX_FOB, D1_CHASSI "							+ CRLF
+	cQuery += " D1_PESO, FT_MVALPIS, FT_MVALCOF, W6_DTREG_D, W6_DI_NUM, 
+	
+	
+	cQuery += "( Select SYD.YD_PER_II from " + RetSqlName("SYD") + " SYD " + CRLF
+ 	cQuery += "	  where SYD.YD_FILIAL  = '" +  FWxFilial('SYD') + "' " + CRLF
+	cQuery += "		AND SYD.YD_TEC     = SB1.B1_POSIPI " + CRLF
+	cQuery += "		AND SYD.YD_EX_NCM  = SB1.B1_EX_NCM " + CRLF
+	cQuery += "		AND SYD.YD_EX_NBM  = SB1.B1_EX_NBM " + CRLF
+    cQuery += "		AND SYD.D_E_L_E_T_ = ' ' " + CRLF
+    cQuery += "		AND     ROWNUM     = 1 " + CRLF
+ 
+    cQuery += "		) as YD_PER_II,  " + CRLF
+
+	cQuery += " VRK_OPCION, W9_TX_FOB, D1_CHASSI "							+ CRLF
 
 	cQuery += " FROM " + RetSQLName('SD1') + " SD1 "																				+ CRLF
 
@@ -207,14 +220,14 @@ Static Function zRel001B(cArquivo)
 	cQuery += " 	ON SW9.W9_FILIAL = '" + FWxFilial('SW9') + "' "																	+ CRLF
 	cQuery += "		AND SW9.W9_HAWB = SD1.D1_CONHEC  "	 																			+ CRLF
 	cQuery += "     AND SW9.D_E_L_E_T_ = ' '   " 																					+ CRLF
-
+/*
 	cQuery += " LEFT JOIN " + RetSQLName("SYD") + " SYD  " 																			+ CRLF
 	cQuery += " 	ON SYD.YD_FILIAL = '" + FWxFilial('SYD') + "' "																	+ CRLF
 	cQuery += "		AND SYD.YD_TEC = SB1.B1_POSIPI "	 																			+ CRLF
 	cQuery += "		AND SYD.YD_EX_NCM = SB1.B1_EX_NCM  "	 																		+ CRLF
 	cQuery += "		AND SYD.YD_EX_NBM = SB1.B1_EX_NBM  "	 																		+ CRLF
 	cQuery += "     AND SYD.D_E_L_E_T_ = ' '   " 																					+ CRLF
-
+*/
 	cQuery += " LEFT JOIN " + RetSQLName("VVF") + " VVF "																			+ CRLF
 	cQuery += "		ON VVF.VVF_FILIAL = '" + FWxFilial('VVF') + "' "																+ CRLF
 	cQuery += " 	AND VVF.VVF_NUMNFI = SF1.F1_DOC "																				+ CRLF
@@ -278,7 +291,7 @@ Static Function zRel001B(cArquivo)
 
 	cQuery += " GROUP BY 	D1_FILIAL, D1_COD, D1_DOC, D1_SERIE, D1_TES, D1_CF, D1_FORNECE, D1_LOJA, D1_EMISSAO, D1_DTDIGIT, " 		+ CRLF
 	cQuery += " D1_ITEM, F4_FINALID, F4_TEXTO, FT_CTIPI, FT_CSTPIS, FT_CSTCOF,  F4_ICM, F4_IPI, F4_CREDICM, F4_CREDIPI, F4_DUPLIC, "+ CRLF
-	cQuery += " B1_DESC, B1_XDESCL1, B1_GRUPO, B1_POSIPI, B1_CEST, B1_ORIGEM, B1_EX_NCM, "											+ CRLF
+	cQuery += " B1_DESC, B1_XDESCL1, B1_GRUPO, B1_POSIPI, B1_CEST, B1_ORIGEM, B1_EX_NCM,  B1_EX_NBM,"											+ CRLF
 	cQuery += "	F1_ESPECIE, F1_CODNFE, F1_MENNOTA, F1_DOC, F1_SERIE, F1_STATUS, F1_TIPO, FT_CHVNFE,"								+ CRLF
 	cQuery += " FT_VALCONT, D1_CONTA, D1_ITEMCTA, D1_NFORI, D1_SERIORI, D1_VUNIT, D1_TOTAL, "										+ CRLF
 	cQuery += " D1_DESC, FT_CLASFIS, FT_BASERET, FT_ICMSRET, D1_DESCZFP, D1_DESCZFC,  "												+ CRLF
@@ -294,7 +307,7 @@ Static Function zRel001B(cArquivo)
 	cQuery += " FT_BASEINS, FT_ALIQINS, D1_ABATINS, D1_AVLINSS, FT_VALINS, C7_NUM, FT_FORMUL, "										+ CRLF
 	cQuery += " D1_BASEISS, D1_ALIQISS, D1_ABATISS, D1_ABATMAT, D1_VALISS, FT_CODBCC, FT_INDNTFR, "									+ CRLF
 	cQuery += " D1_VALFRE, D1_DESPESA, D1_CUSTO, D1_SEGURO, D1_VALACRS, D1_II, FT_ICMSCOM, D1_TNATREC, D1_CONHEC,  "				+ CRLF
-	cQuery += " D1_PESO, FT_MVALPIS, FT_MVALCOF, W6_DTREG_D, W6_DI_NUM, YD_PER_II, VRK_OPCION, W9_TX_FOB, D1_CHASSI "							+ CRLF
+	cQuery += " D1_PESO, FT_MVALPIS, FT_MVALCOF, W6_DTREG_D, W6_DI_NUM,  VRK_OPCION, W9_TX_FOB, D1_CHASSI "							+ CRLF
 
 	cQuery += " ORDER BY SD1.D1_FILIAL, SD1.D1_EMISSAO, SD1.D1_DOC, SD1.D1_SERIE, SD1.D1_TES, SD1.D1_ITEM, SD1.D1_FORNECE, SD1.D1_LOJA "+ CRLF
 

--- a/SIGAFIS/Relatorio/ZFISR009.prw
+++ b/SIGAFIS/Relatorio/ZFISR009.prw
@@ -146,17 +146,30 @@ Static Function zRel0001(cArquivo)
 	cQuery += " FT_BASEINS, FT_ALIQINS, D1_ABATINS, D1_AVLINSS, FT_VALINS, C7_NUM, FT_FORMUL, "										+ CRLF
 	cQuery += " D1_BASEISS, D1_ALIQISS, D1_ABATISS, D1_ABATMAT, D1_VALISS, FT_CODBCC, FT_INDNTFR, "									+ CRLF
 	cQuery += " D1_VALFRE, D1_DESPESA, D1_CUSTO, D1_SEGURO, D1_VALACRS, D1_II, FT_ICMSCOM, D1_TNATREC, D1_CONHEC, "					+ CRLF
-	cQuery += " D1_PESO, FT_MVALPIS, FT_MVALCOF, W6_DTREG_D, W6_DI_NUM, YD_PER_II, VRK_OPCION, W9_TX_FOB "							+ CRLF
+	cQuery += " D1_PESO, FT_MVALPIS, FT_MVALCOF, W6_DTREG_D, W6_DI_NUM,	" + CRLF
+
+	
+	cQuery += "( Select SYD.YD_PER_II from " + RetSqlName("SYD") + " SYD " + CRLF
+ 	cQuery += "	  where SYD.YD_FILIAL  = '" +  FWxFilial('SYD') + "' " + CRLF
+	cQuery += "		AND SYD.YD_TEC     = SB1.B1_POSIPI " + CRLF
+	cQuery += "		AND SYD.YD_EX_NCM  = SB1.B1_EX_NCM " + CRLF
+	cQuery += "		AND SYD.YD_EX_NBM  = SB1.B1_EX_NBM " + CRLF
+    cQuery += "		AND SYD.D_E_L_E_T_ = ' ' " + CRLF
+    cQuery += "		AND     ROWNUM     = 1 " + CRLF
+ 
+    cQuery += "		) as YD_PER_II,  " + CRLF
+
+	cQuery += " VRK_OPCION, W9_TX_FOB "							+ CRLF
 
 	cQuery += " FROM " + RetSQLName('SD1') + " SD1 "																				+ CRLF
 
 	cQuery += " INNER JOIN " + RetSQLName('SF1') + " SF1 "			 																+ CRLF
-	cQuery += " 	ON SF1.F1_FILIAL = '" + FWxFilial('SF1') + "' "																	+ CRLF
-	cQuery += " 	AND SF1.F1_DOC = SD1.D1_DOC " 																					+ CRLF
-	cQuery += " 	AND SF1.F1_SERIE = SD1.D1_SERIE " 																				+ CRLF
+	cQuery += " 	ON  SF1.F1_FILIAL  = '" + FWxFilial('SF1') + "' "																	+ CRLF
+	cQuery += " 	AND SF1.F1_DOC     = SD1.D1_DOC " 																					+ CRLF
+	cQuery += " 	AND SF1.F1_SERIE   = SD1.D1_SERIE " 																				+ CRLF
 	cQuery += " 	AND SF1.F1_FORNECE = SD1.D1_FORNECE " 																			+ CRLF
-	cQuery += " 	AND SF1.F1_LOJA = SD1.D1_LOJA " 																				+ CRLF
-	cQuery += " 	AND SF1.F1_ESPECIE BETWEEN '" +MV_PAR03+ "' AND '" +MV_PAR04+ "' " 												+ CRLF
+	cQuery += " 	AND SF1.F1_LOJA    = SD1.D1_LOJA " 																				+ CRLF
+	cQuery += " 	AND SF1.F1_ESPECIE BETWEEN '" + MV_PAR03 + "' AND '" + MV_PAR04 + "' " 												+ CRLF
 	cQuery += " 	AND SF1.D_E_L_E_T_ = ' ' " 																						+ CRLF	
 
 	If !Empty(MV_PAR19)
@@ -164,8 +177,8 @@ Static Function zRel0001(cArquivo)
 	EndIf 
 
 	cQuery += " INNER JOIN " + RetSQLName("SB1") + " SB1  " 																		+ CRLF
-	cQuery += " 	ON SB1.B1_FILIAL = '" + FWxFilial('SB1') + "'  "																+ CRLF
-	cQuery += "		AND SB1.B1_COD = SD1.D1_COD  "	 																				+ CRLF
+	cQuery += " 	ON  SB1.B1_FILIAL  = '" + FWxFilial('SB1') + "'  "																+ CRLF
+	cQuery += "		AND SB1.B1_COD     = SD1.D1_COD  "	 																				+ CRLF
 	cQuery += "     AND SB1.D_E_L_E_T_ = ' '   " 																					+ CRLF
 	
 	If !Empty( MV_PAR20 )
@@ -177,74 +190,74 @@ Static Function zRel0001(cArquivo)
 	EndIf
 
 	cQuery += " INNER JOIN " + RetSQLName("SF4") + " SF4 " 																			+ CRLF
-	cQuery += " 	ON SF4.F4_FILIAL = '" + FWxFilial('SF4') + "'  "																+ CRLF
-	cQuery += "		AND SF4.F4_CODIGO = SD1.D1_TES  "	 																			+ CRLF
+	cQuery += " 	ON  SF4.F4_FILIAL  = '" + FWxFilial('SF4') + "'  "																+ CRLF
+	cQuery += "		AND SF4.F4_CODIGO  = SD1.D1_TES  "	 																			+ CRLF
 	cQuery += "     AND SF4.D_E_L_E_T_ = ' '   " 																					+ CRLF
 
 	cQuery += " LEFT JOIN " + RetSQLName("SW6") + " SW6  " 																			+ CRLF
-	cQuery += " 	ON SW6.W6_FILIAL = '" + FWxFilial('SW6') + "' "																	+ CRLF
-	cQuery += "		AND SW6.W6_HAWB = SD1.D1_CONHEC  "	 																			+ CRLF
+	cQuery += " 	ON  SW6.W6_FILIAL  = '" + FWxFilial('SW6') + "' "																	+ CRLF
+	cQuery += "		AND SW6.W6_HAWB    = SD1.D1_CONHEC  "	 																			+ CRLF
 	cQuery += "     AND SW6.D_E_L_E_T_ = ' '   " 																					+ CRLF
 
 	cQuery += " LEFT JOIN " + RetSQLName("SW9") + " SW9  " 																			+ CRLF
-	cQuery += " 	ON SW9.W9_FILIAL = '" + FWxFilial('SW9') + "' "																	+ CRLF
-	cQuery += "		AND SW9.W9_HAWB = SD1.D1_CONHEC  "	 																			+ CRLF
+	cQuery += " 	ON  SW9.W9_FILIAL  = '" + FWxFilial('SW9') + "' "																	+ CRLF
+	cQuery += "		AND SW9.W9_HAWB    = SD1.D1_CONHEC  "	 																			+ CRLF
 	cQuery += "     AND SW9.D_E_L_E_T_ = ' '   " 																					+ CRLF
-
+/*
 	cQuery += " LEFT JOIN " + RetSQLName("SYD") + " SYD  " 																			+ CRLF
-	cQuery += " 	ON SYD.YD_FILIAL = '" + FWxFilial('SYD') + "' "																	+ CRLF
-	cQuery += "		AND SYD.YD_TEC = SB1.B1_POSIPI "	 																			+ CRLF
-	cQuery += "		AND SYD.YD_EX_NCM = SB1.B1_EX_NCM  "	 																		+ CRLF
-	cQuery += "		AND SYD.YD_EX_NBM = SB1.B1_EX_NBM  "	 																		+ CRLF
+	cQuery += " 	ON  SYD.YD_FILIAL  = '" + FWxFilial('SYD') + "' "																	+ CRLF
+	cQuery += "		AND SYD.YD_TEC     = SB1.B1_POSIPI "	 																			+ CRLF
+	cQuery += "		AND SYD.YD_EX_NCM  = SB1.B1_EX_NCM  "	 																		+ CRLF
+	cQuery += "		AND SYD.YD_EX_NBM  = SB1.B1_EX_NBM  "	 																		+ CRLF
 	cQuery += "     AND SYD.D_E_L_E_T_ = ' '   " 																					+ CRLF
-
+*/
 	cQuery += " LEFT JOIN " + RetSQLName("VVF") + " VVF "																			+ CRLF
-	cQuery += "		ON VVF.VVF_FILIAL = '" + FWxFilial('VVF') + "' "																+ CRLF
+	cQuery += "		ON  VVF.VVF_FILIAL = '" + FWxFilial('VVF') + "' "																+ CRLF
 	cQuery += " 	AND VVF.VVF_NUMNFI = SF1.F1_DOC "																				+ CRLF
 	cQuery += " 	AND VVF.VVF_SERNFI = SF1.F1_SERIE " 																			+ CRLF
 	cQuery += " 	AND VVF.VVF_CODFOR = SF1.F1_FORNECE " 																			+ CRLF
-	cQuery += " 	AND VVF.VVF_LOJA = SF1.F1_LOJA " 																				+ CRLF
+	cQuery += " 	AND VVF.VVF_LOJA   = SF1.F1_LOJA " 																				+ CRLF
 	cQuery += " 	AND VVF.D_E_L_E_T_ = ' ' "																	 					+ CRLF
 
 	cQuery += " LEFT JOIN " + RetSQLName("SC7") + " SC7 "																			+ CRLF
-	cQuery += " 	ON SC7.C7_FILIAL = '" + FWxFilial('SC7') + "' "																	+ CRLF
-	cQuery += "		AND SC7.C7_NUM = SD1.D1_PEDIDO "																				+ CRLF
-	cQuery += "		AND SC7.C7_ITEM = SD1.D1_ITEMPC "												 								+ CRLF
+	cQuery += " 	ON  SC7.C7_FILIAL  = '" + FWxFilial('SC7') + "' "																	+ CRLF
+	cQuery += "		AND SC7.C7_NUM     = SD1.D1_PEDIDO "																				+ CRLF
+	cQuery += "		AND SC7.C7_ITEM    = SD1.D1_ITEMPC "												 								+ CRLF
 	cQuery += "		AND SC7.D_E_L_E_T_ = ' ' "																						+ CRLF
 	
 	cQuery += " LEFT JOIN " + RetSQLName("VRK") + " VRK "																			+ CRLF
-	cQuery += " 	ON VRK.VRK_FILIAL = '" + FWxFilial('VRK') + "' "  																+ CRLF
+	cQuery += " 	ON  VRK.VRK_FILIAL = '" + FWxFilial('VRK') + "' "  																+ CRLF
 	cQuery += "		AND VRK.VRK_PEDIDO = SD1.D1_PEDIDO	"																			+ CRLF
     cQuery += "     AND VRK.VRK_ITEPED = SD1.D1_ITEMPC	"																			+ CRLF
 	cQuery += "     AND VRK.D_E_L_E_T_ = ' '   " 																					+ CRLF
 
 	cQuery += " INNER JOIN " + RetSQLName("SFT") + " SFT " 																			+ CRLF
-	cQuery += "		ON SFT.FT_FILIAL = '" + FWxFilial('SFT') + "' "																	+ CRLF
+	cQuery += "		ON  SFT.FT_FILIAL  = '" + FWxFilial('SFT') + "' "																	+ CRLF
 	cQuery += "		AND SFT.FT_TIPOMOV = 'E' "																						+ CRLF
-	cQuery += "		AND SFT.FT_SERIE = SD1.D1_SERIE "																				+ CRLF
+	cQuery += "		AND SFT.FT_SERIE   = SD1.D1_SERIE "																				+ CRLF
 	cQuery += " 	AND SFT.FT_NFISCAL = SD1.D1_DOC "																				+ CRLF
 	cQuery += "		AND SFT.FT_CLIEFOR = SD1.D1_FORNECE " 																			+ CRLF
-	cQuery += "		AND SFT.FT_LOJA = SD1.D1_LOJA " 																				+ CRLF
-	cQuery += "		AND SFT.FT_ITEM = SD1.D1_ITEM " 																				+ CRLF
+	cQuery += "		AND SFT.FT_LOJA    = SD1.D1_LOJA " 																				+ CRLF
+	cQuery += "		AND SFT.FT_ITEM    = SD1.D1_ITEM " 																				+ CRLF
 	cQuery += "		AND SFT.FT_PRODUTO = SD1.D1_COD " 																				+ CRLF	
 	cQuery += "		AND SFT.D_E_L_E_T_ = ' ' "																						+ CRLF
 
 	cQuery += " INNER JOIN " + RetSQLName("SF3") + " SF3 " 																			+ CRLF
-	cQuery += "		ON SF3.F3_FILIAL = '" + FWxFilial('SF3') + "' "																	+ CRLF
-	cQuery += "		AND SF3.F3_SERIE = SFT.FT_SERIE "																				+ CRLF
+	cQuery += "		ON  SF3.F3_FILIAL  = '" + FWxFilial('SF3') + "' "																	+ CRLF
+	cQuery += "		AND SF3.F3_SERIE   = SFT.FT_SERIE "																				+ CRLF
 	cQuery += "		AND SF3.F3_NFISCAL = SFT.FT_NFISCAL "																			+ CRLF
 	cQuery += " 	AND SF3.F3_CLIEFOR = SFT.FT_CLIEFOR "																			+ CRLF
-	cQuery += "		AND SF3.F3_LOJA = SFT.FT_LOJA " 																				+ CRLF
+	cQuery += "		AND SF3.F3_LOJA    = SFT.FT_LOJA " 																				+ CRLF
 	cQuery += "		AND SF3.F3_IDENTFT = SFT.FT_IDENTF3 " 																			+ CRLF
 	cQuery += "		AND SF3.D_E_L_E_T_ = ' ' "																						+ CRLF
 
-	cQuery += " WHERE SD1.D1_FILIAL BETWEEN '" + MV_PAR01 + "' AND '" + MV_PAR02 + "' " 											+ CRLF
-	cQuery += " 	AND SD1.D1_DOC BETWEEN '" + MV_PAR05 + "' AND '" + MV_PAR06 + "' " 												+ CRLF
-	cQuery += " 	AND SD1.D1_SERIE BETWEEN '" + MV_PAR07 + "' AND '" + MV_PAR08 + "' " 											+ CRLF
-	cQuery += " 	AND SD1.D1_FORNECE BETWEEN '" + MV_PAR09 + "' AND '" + MV_PAR10 + "' " 											+ CRLF
+	cQuery += " WHERE   SD1.D1_FILIAL  BETWEEN '" +       MV_PAR01   + "' AND '" +       MV_PAR02   + "' " 						    + CRLF
+	cQuery += " 	AND SD1.D1_DOC     BETWEEN '" +       MV_PAR05   + "' AND '" +       MV_PAR06   + "' " 						    + CRLF
+	cQuery += " 	AND SD1.D1_SERIE   BETWEEN '" +       MV_PAR07   + "' AND '" +       MV_PAR08   + "' " 						    + CRLF
+	cQuery += " 	AND SD1.D1_FORNECE BETWEEN '" +       MV_PAR09   + "' AND '" +       MV_PAR10   + "' " 						    + CRLF
 	cQuery += " 	AND SD1.D1_DTDIGIT BETWEEN '" + DToS( MV_PAR11 ) + "' AND '" + DToS( MV_PAR12 ) + "' " 							+ CRLF
 	cQuery += " 	AND SD1.D1_EMISSAO BETWEEN '" + DToS( MV_PAR13 ) + "' AND '" + DToS( MV_PAR14 ) + "' " 							+ CRLF
-	cQuery += " 	AND SD1.D1_COD BETWEEN '" + MV_PAR15 + "' AND '" + MV_PAR16 + "' " 												+ CRLF
+	cQuery += " 	AND SD1.D1_COD     BETWEEN '" +       MV_PAR15   + "' AND '" +       MV_PAR16   + "' " 											+ CRLF
 	cQuery += " 	AND SD1.D_E_L_E_T_ = ' ' "	 																					+ CRLF
 
 	If !Empty( MV_PAR17 )
@@ -257,8 +270,8 @@ Static Function zRel0001(cArquivo)
 
 	cQuery += " GROUP BY 	D1_FILIAL, D1_COD, D1_DOC, D1_SERIE, D1_TES, D1_CF, D1_FORNECE, D1_LOJA, D1_EMISSAO, D1_DTDIGIT, " 		+ CRLF
 	cQuery += " D1_ITEM, F4_FINALID, F4_TEXTO, FT_CTIPI, FT_CSTPIS, FT_CSTCOF,  F4_ICM, F4_IPI, F4_CREDICM, F4_CREDIPI, F4_DUPLIC, "+ CRLF
-	cQuery += " B1_DESC, B1_XDESCL1, B1_GRUPO, B1_POSIPI, B1_CEST, B1_ORIGEM, B1_EX_NCM, "											+ CRLF
-	cQuery += "	F1_ESPECIE, F1_CODNFE, F1_MENNOTA, F1_DOC, F1_SERIE, F1_STATUS, F1_TIPO, FT_CHVNFE,"								+ CRLF
+	cQuery += " B1_DESC, B1_XDESCL1, B1_GRUPO, B1_POSIPI, B1_CEST, B1_ORIGEM, B1_EX_NCM, B1_EX_NBM, "								+ CRLF
+	cQuery += "	F1_ESPECIE, F1_CODNFE, F1_MENNOTA, F1_DOC, F1_SERIE, F1_STATUS, F1_TIPO, FT_CHVNFE, "								+ CRLF
 	cQuery += " FT_VALCONT, D1_CONTA, D1_ITEMCTA, D1_NFORI, D1_SERIORI, D1_VUNIT, D1_TOTAL, "										+ CRLF
 	cQuery += " D1_DESC, FT_CLASFIS, FT_BASERET, FT_ICMSRET, D1_DESCZFP, D1_DESCZFC,  "												+ CRLF
 	cQuery += " F1_UFORITR, F1_MUORITR, F1_UFDESTR, F1_MUDESTR,  "																	+ CRLF
@@ -273,7 +286,7 @@ Static Function zRel0001(cArquivo)
 	cQuery += " FT_BASEINS, FT_ALIQINS, D1_ABATINS, D1_AVLINSS, FT_VALINS, C7_NUM, FT_FORMUL, "										+ CRLF
 	cQuery += " D1_BASEISS, D1_ALIQISS, D1_ABATISS, D1_ABATMAT, D1_VALISS, FT_CODBCC, FT_INDNTFR, "									+ CRLF
 	cQuery += " D1_VALFRE, D1_DESPESA, D1_CUSTO, D1_SEGURO, D1_VALACRS, D1_II, FT_ICMSCOM, D1_TNATREC, D1_CONHEC,  "				+ CRLF
-	cQuery += " D1_PESO, FT_MVALPIS, FT_MVALCOF, W6_DTREG_D, W6_DI_NUM, YD_PER_II, VRK_OPCION, W9_TX_FOB "							+ CRLF
+	cQuery += " D1_PESO, FT_MVALPIS, FT_MVALCOF, W6_DTREG_D, W6_DI_NUM, VRK_OPCION, W9_TX_FOB "		     							+ CRLF
 
 	cQuery += " ORDER BY SD1.D1_FILIAL, SD1.D1_EMISSAO, SD1.D1_DOC, SD1.D1_SERIE, SD1.D1_ITEM, SD1.D1_FORNECE, SD1.D1_LOJA "		+ CRLF
 
@@ -674,9 +687,9 @@ Static Function zRel0001(cArquivo)
 														nTotal ,; //(cAliasTRB)->D1_TOTAL,;    //--Valor Total Item
 														(cAliasTRB)->D1_CF,;    //--Cfop
 														(cAliasTRB)->FT_VALCONT,;    //--Valor Contábil
-														iif( Alltrim((cAliasTRB)->F1_ESPECIE) <> "RPS", (cAliasTRB)->FT_BASEICM , 0),; //(cAliasTRB)->FT_BASEICM,;    //--Base ICMS
-														iif( Alltrim((cAliasTRB)->F1_ESPECIE) <> "RPS", (cAliasTRB)->FT_ALIQICM , 0),; //(cAliasTRB)->FT_ALIQICM,;    //--Aliq. ICMS
-														iif( Alltrim((cAliasTRB)->F1_ESPECIE) <> "RPS", (cAliasTRB)->FT_VALICM  , 0),; //(cAliasTRB)->FT_VALICM,;    //--Valor ICMS
+														iif( Alltrim((cAliasTRB)->F1_ESPECIE) <> "RPS", (cAliasTRB)->FT_BASEICM , 0),;   //(cAliasTRB)->FT_BASEICM,;    //--Base ICMS
+														iif( Alltrim((cAliasTRB)->F1_ESPECIE) <> "RPS", (cAliasTRB)->FT_ALIQICM , 0),;   //(cAliasTRB)->FT_ALIQICM,;    //--Aliq. ICMS
+														iif( Alltrim((cAliasTRB)->F1_ESPECIE) <> "RPS", (cAliasTRB)->FT_VALICM  , 0),;   //(cAliasTRB)->FT_VALICM,;    //--Valor ICMS
 														IIF( (cAliasTRB)->F1_TIPO $ "B|D" , nVlCom , 0 ),;    //--Comissão
 														(cAliasTRB)->FT_BASEIPI,;    //--Base IPI					
 														(cAliasTRB)->FT_ALIQIPI,;    //--Aliq. IPI			

--- a/SIGAFIS/Relatorio/ZFISR010.prw
+++ b/SIGAFIS/Relatorio/ZFISR010.prw
@@ -563,33 +563,44 @@ Static Function zTmpRadio1()
 	EndIf
 
 	cQuery += " SELECT 	D1_FILIAL, D1_COD, D1_DOC, D1_SERIE, D1_TES, D1_CF, D1_FORNECE, D1_LOJA, D1_EMISSAO, D1_DTDIGIT, " 			+ CRLF
-	cQuery += " D1_ITEM, F4_FINALID, F4_TEXTO, FT_CTIPI, FT_CSTPIS, FT_CSTCOF, F4_ICM, F4_IPI, F4_CREDICM, F4_CREDIPI, F4_DUPLIC, "	+ CRLF
-	cQuery += "	B1_DESC, B1_XDESCL1, B1_GRUPO, B1_POSIPI, B1_CEST, B1_ORIGEM, B1_EX_NCM, B1_EX_NBM,"								  			+ CRLF
-	cQuery += "	F1_ESPECIE, F1_CODNFE, F1_MENNOTA, F1_DOC, F1_SERIE, F1_STATUS, F1_TIPO, FT_CHVNFE, "								+ CRLF
-	cQuery += " FT_VALCONT, D1_CONTA, D1_ITEMCTA, D1_NFORI, D1_SERIORI, D1_VUNIT, D1_TOTAL, "										+ CRLF
-	cQuery += " D1_VALDESC, FT_CLASFIS, FT_BASERET, FT_ICMSRET, D1_DESCZFP, D1_DESCZFC,  "												+ CRLF
-	cQuery += " F1_UFORITR, F1_MUORITR, F1_UFDESTR, F1_MUDESTR,  "																	+ CRLF
-	cQuery += " FT_BASEICM, FT_ALIQICM, FT_VALICM, FT_BRETPIS, FT_ARETPIS, FT_VRETPIS, FT_BRETCOF, FT_ARETCOF, FT_VRETCOF, " 		+ CRLF
-	cQuery += " FT_BASEIPI, FT_ALIQIPI, FT_VALIPI, " 																				+ CRLF
-	cQuery += " D1_BASIMP6, D1_ALQIMP6, D1_VALIMP6, " 																				+ CRLF
-	cQuery += " D1_BASIMP5, D1_ALQIMP5, D1_VALIMP5, "													                            + CRLF
-	cQuery += " FT_BASEPIS, FT_ALIQPIS, FT_VALPIS, FT_ALIQPS3, FT_VALPS3, "															+ CRLF
-	cQuery += " FT_BASECOF, FT_ALIQCOF, FT_VALCOF, FT_DIFAL, FT_BASECF3, FT_ALIQCF3, FT_VALCF3, FT_BASEPS3, "						+ CRLF
-	cQuery += " FT_BASEIRR, FT_ALIQIRR, FT_VALIRR, F3_OUTRIPI, F3_ISENIPI, F3_OUTRICM, F3_ISENICM, " 								+ CRLF
-	cQuery += " FT_BASECSL, FT_ALIQCSL, FT_VALCSL, D1_UM, D1_QUANT, D1_CHASSI, "													+ CRLF
-	cQuery += " FT_BASEINS, FT_ALIQINS, D1_ABATINS, D1_AVLINSS, FT_VALINS, C7_NUM, FT_FORMUL, "										+ CRLF
-	cQuery += " D1_BASEISS, D1_ALIQISS, D1_ABATISS, D1_ABATMAT, D1_VALISS, FT_CODBCC, FT_INDNTFR, "									+ CRLF
-	cQuery += " D1_VALFRE, D1_DESPESA, D1_CUSTO, D1_SEGURO, D1_VALACRS, D1_II, FT_ICMSCOM, D1_TNATREC, D1_CONHEC, "					+ CRLF
-	cQuery += " D1_PESO, FT_MVALPIS, FT_MVALCOF, W6_DTREG_D, W6_DI_NUM, YD_PER_II, VRK_OPCION, W9_TX_FOB " 					        + CRLF
+	cQuery += "         D1_ITEM, F4_FINALID, F4_TEXTO, FT_CTIPI, FT_CSTPIS, FT_CSTCOF, F4_ICM, F4_IPI, F4_CREDICM, F4_CREDIPI, F4_DUPLIC, "	+ CRLF
+	cQuery += "	        B1_DESC, B1_XDESCL1, B1_GRUPO, B1_POSIPI, B1_CEST, B1_ORIGEM, B1_EX_NCM, B1_EX_NBM,"								  			+ CRLF
+	cQuery += "	        F1_ESPECIE, F1_CODNFE, F1_MENNOTA, F1_DOC, F1_SERIE, F1_STATUS, F1_TIPO, FT_CHVNFE, "								+ CRLF
+	cQuery += "         FT_VALCONT, D1_CONTA, D1_ITEMCTA, D1_NFORI, D1_SERIORI, D1_VUNIT, D1_TOTAL, "										+ CRLF
+	cQuery += "         D1_VALDESC, FT_CLASFIS, FT_BASERET, FT_ICMSRET, D1_DESCZFP, D1_DESCZFC,  "												+ CRLF
+	cQuery += "         F1_UFORITR, F1_MUORITR, F1_UFDESTR, F1_MUDESTR,  "																	+ CRLF
+	cQuery += "         FT_BASEICM, FT_ALIQICM, FT_VALICM, FT_BRETPIS, FT_ARETPIS, FT_VRETPIS, FT_BRETCOF, FT_ARETCOF, FT_VRETCOF, " 		+ CRLF
+	cQuery += "         FT_BASEIPI, FT_ALIQIPI, FT_VALIPI, " 																				+ CRLF
+	cQuery += "         D1_BASIMP6, D1_ALQIMP6, D1_VALIMP6, " 																				+ CRLF
+	cQuery += "         D1_BASIMP5, D1_ALQIMP5, D1_VALIMP5, "													                            + CRLF
+	cQuery += "         FT_BASEPIS, FT_ALIQPIS, FT_VALPIS, FT_ALIQPS3, FT_VALPS3, "															+ CRLF
+	cQuery += "         FT_BASECOF, FT_ALIQCOF, FT_VALCOF, FT_DIFAL, FT_BASECF3, FT_ALIQCF3, FT_VALCF3, FT_BASEPS3, "						+ CRLF
+	cQuery += "         FT_BASEIRR, FT_ALIQIRR, FT_VALIRR, F3_OUTRIPI, F3_ISENIPI, F3_OUTRICM, F3_ISENICM, " 								+ CRLF
+	cQuery += "         FT_BASECSL, FT_ALIQCSL, FT_VALCSL, D1_UM, D1_QUANT, D1_CHASSI, "													+ CRLF
+	cQuery += "         FT_BASEINS, FT_ALIQINS, D1_ABATINS, D1_AVLINSS, FT_VALINS, C7_NUM, FT_FORMUL, "										+ CRLF
+	cQuery += "         D1_BASEISS, D1_ALIQISS, D1_ABATISS, D1_ABATMAT, D1_VALISS, FT_CODBCC, FT_INDNTFR, "									+ CRLF
+	cQuery += "         D1_VALFRE, D1_DESPESA, D1_CUSTO, D1_SEGURO, D1_VALACRS, D1_II, FT_ICMSCOM, D1_TNATREC, D1_CONHEC, "					+ CRLF
+	cQuery += "         D1_PESO, FT_MVALPIS, FT_MVALCOF, W6_DTREG_D, W6_DI_NUM, " + CRLF
+
+    cQuery += "        ( Select SYD.YD_PER_II from " + RetSqlName("SYD") + " SYD " + CRLF
+ 	cQuery += "	          where SYD.YD_FILIAL  = '" +  FWxFilial('SYD') + "' " + CRLF
+	cQuery += "	        	AND SYD.YD_TEC     = SB1.B1_POSIPI " + CRLF
+	cQuery += "	        	AND SYD.YD_EX_NCM  = SB1.B1_EX_NCM " + CRLF
+	cQuery += "	        	AND SYD.YD_EX_NBM  = SB1.B1_EX_NBM " + CRLF
+    cQuery += "	        	AND SYD.D_E_L_E_T_ = ' ' " + CRLF
+    cQuery += "	        	AND     ROWNUM     = 1 " + CRLF
+    cQuery += "	        	) as YD_PER_II,  " + CRLF
+
+    cQuery += "        VRK_OPCION, W9_TX_FOB " 					        + CRLF
 
 	cQuery += " FROM " + RetSQLName('SD1') + " SD1 "																				+ CRLF
 
 	cQuery += " INNER JOIN " + RetSQLName('SF1') + " SF1 "			 																+ CRLF
-	cQuery += " 	ON SF1.F1_FILIAL = '" + FWxFilial('SF1') + "' "																    + CRLF	
-	cQuery += " 	AND SF1.F1_DOC = SD1.D1_DOC " 																					+ CRLF
-	cQuery += " 	AND SF1.F1_SERIE = SD1.D1_SERIE " 																				+ CRLF
+	cQuery += " 	ON  SF1.F1_FILIAL  = '" + FWxFilial('SF1') + "' "																    + CRLF	
+	cQuery += " 	AND SF1.F1_DOC     = SD1.D1_DOC " 																					+ CRLF
+	cQuery += " 	AND SF1.F1_SERIE   = SD1.D1_SERIE " 																				+ CRLF
 	cQuery += " 	AND SF1.F1_FORNECE = SD1.D1_FORNECE " 																			+ CRLF
-	cQuery += " 	AND SF1.F1_LOJA = SD1.D1_LOJA " 																				+ CRLF
+	cQuery += " 	AND SF1.F1_LOJA    = SD1.D1_LOJA " 																				+ CRLF
 	cQuery += " 	AND SF1.F1_ESPECIE BETWEEN '" +MV_PAR03+ "' AND '" +MV_PAR04+ "' " 												+ CRLF
 	cQuery += " 	AND SF1.D_E_L_E_T_ = ' ' " 																						+ CRLF	
 
@@ -598,8 +609,8 @@ Static Function zTmpRadio1()
 	EndIf 
 
 	cQuery += " INNER JOIN " + RetSQLName("SB1") + " SB1  " 																		+ CRLF
-	cQuery += " 	ON SB1.B1_FILIAL = '" + FWxFilial('SB1') + "'  "															    + CRLF
-	cQuery += "		AND SB1.B1_COD = SD1.D1_COD  "	 																				+ CRLF
+	cQuery += " 	ON  SB1.B1_FILIAL = '" + FWxFilial('SB1') + "'  "															    + CRLF
+	cQuery += "		AND SB1.B1_COD    = SD1.D1_COD  "	 																				+ CRLF
 	cQuery += "     AND SB1.D_E_L_E_T_ = ' '   " 																					+ CRLF
 	
 	If !Empty( MV_PAR20 )
@@ -611,29 +622,29 @@ Static Function zTmpRadio1()
 	EndIf
 
 	cQuery += " INNER JOIN " + RetSQLName("SF4") + " SF4 " 																			+ CRLF
-	cQuery += " 	ON SF4.F4_FILIAL = '" + FWxFilial('SF4') + "'  "															    + CRLF
-	cQuery += "		AND SF4.F4_CODIGO = SD1.D1_TES  "	 																			+ CRLF
+	cQuery += " 	ON  SF4.F4_FILIAL  = '" + FWxFilial('SF4') + "'  "															    + CRLF
+	cQuery += "		AND SF4.F4_CODIGO  = SD1.D1_TES  "	 																			+ CRLF
 	cQuery += "     AND SF4.D_E_L_E_T_ = ' '   " 																					+ CRLF
 
 	cQuery += " LEFT JOIN " + RetSQLName("SW6") + " SW6  " 																			+ CRLF
-	cQuery += " 	ON SW6.W6_FILIAL = '" + FWxFilial('SW6') + "' "																    + CRLF
-	cQuery += "		AND SW6.W6_HAWB = SD1.D1_CONHEC  "	 																			+ CRLF
+	cQuery += " 	ON  SW6.W6_FILIAL  = '" + FWxFilial('SW6') + "' "																+ CRLF
+	cQuery += "		AND SW6.W6_HAWB    = SD1.D1_CONHEC  "	 																		+ CRLF
 	cQuery += "     AND SW6.D_E_L_E_T_ = ' '   " 																					+ CRLF
 
     cQuery += " LEFT JOIN " + RetSQLName("SW9") + " SW9  " 																			+ CRLF
-	cQuery += " 	ON SW9.W9_FILIAL = '" + FWxFilial('SW9') + "' "																	+ CRLF
-	cQuery += "		AND SW9.W9_HAWB = SD1.D1_CONHEC  "	 																			+ CRLF
+	cQuery += " 	ON  SW9.W9_FILIAL  = '" + FWxFilial('SW9') + "' "																+ CRLF
+	cQuery += "		AND SW9.W9_HAWB    = SD1.D1_CONHEC  "	 																		+ CRLF
 	cQuery += "     AND SW9.D_E_L_E_T_ = ' '   " 																					+ CRLF
-
+/*
 	cQuery += " LEFT JOIN " + RetSQLName("SYD") + " SYD  " 																			+ CRLF
 	cQuery += " 	ON SYD.YD_FILIAL = '" + FWxFilial('SYD') + "' "																    + CRLF
     cQuery += "		AND SYD.YD_TEC = SB1.B1_POSIPI "	 																			+ CRLF
 	cQuery += "		AND SYD.YD_EX_NCM = SB1.B1_EX_NCM  "	 																		+ CRLF
 	cQuery += "		AND SYD.YD_EX_NBM = SB1.B1_EX_NBM  "	 																		+ CRLF
 	cQuery += "     AND SYD.D_E_L_E_T_ = ' '   " 																					+ CRLF
-
+*/
 	cQuery += " LEFT JOIN " + RetSQLName("VVF") + " VVF "																			+ CRLF
-	cQuery += "		ON VVF.VVF_FILIAL = '" + FWxFilial('VVF') + "' "															    + CRLF
+	cQuery += "		ON  VVF.VVF_FILIAL = '" + FWxFilial('VVF') + "' "															    + CRLF
 	cQuery += " 	AND VVF.VVF_NUMNFI = SF1.F1_DOC "																				+ CRLF
 	cQuery += " 	AND VVF.VVF_SERNFI = SF1.F1_SERIE " 																			+ CRLF
 	cQuery += " 	AND VVF.VVF_CODFOR = SF1.F1_FORNECE " 																			+ CRLF
@@ -641,25 +652,25 @@ Static Function zTmpRadio1()
 	cQuery += " 	AND VVF.D_E_L_E_T_ = ' ' "																	 					+ CRLF
 
 	cQuery += " LEFT JOIN " + RetSQLName("SC7") + " SC7 "																			+ CRLF
-	cQuery += " 	ON SC7.C7_FILIAL = '" + FWxFilial('SC7') + "' "																    + CRLF
-	cQuery += "		AND SC7.C7_NUM = SD1.D1_PEDIDO "																				+ CRLF
-	cQuery += "		AND SC7.C7_ITEM = SD1.D1_ITEMPC "												 								+ CRLF
+	cQuery += " 	ON  SC7.C7_FILIAL  = '" + FWxFilial('SC7') + "' "																    + CRLF
+	cQuery += "		AND SC7.C7_NUM     = SD1.D1_PEDIDO "																				+ CRLF
+	cQuery += "		AND SC7.C7_ITEM    = SD1.D1_ITEMPC "												 								+ CRLF
 	cQuery += "		AND SC7.D_E_L_E_T_ = ' ' "																						+ CRLF
 	
 	cQuery += " LEFT JOIN " + RetSQLName("VRK") + " VRK "																			+ CRLF
-	cQuery += " 	ON VRK.VRK_FILIAL = '" + FWxFilial('VRK') + "' "  															    + CRLF
+	cQuery += " 	ON  VRK.VRK_FILIAL = '" + FWxFilial('VRK') + "' "  															    + CRLF
 	cQuery += "		AND VRK.VRK_PEDIDO = SD1.D1_PEDIDO	"																			+ CRLF
     cQuery += "     AND VRK.VRK_ITEPED = SD1.D1_ITEMPC	"																			+ CRLF
 	cQuery += "     AND VRK.D_E_L_E_T_ = ' '   " 																					+ CRLF
 
 	cQuery += " INNER JOIN " + RetSQLName("SFT") + " SFT " 																			+ CRLF
-	cQuery += "		ON SFT.FT_FILIAL = '" + FWxFilial('SFT') + "' "																    + CRLF
+	cQuery += "		ON  SFT.FT_FILIAL  = '" + FWxFilial('SFT') + "' "																    + CRLF
 	cQuery += "		AND SFT.FT_TIPOMOV = 'E' "																						+ CRLF
-	cQuery += "		AND SFT.FT_SERIE = SD1.D1_SERIE "																				+ CRLF
+	cQuery += "		AND SFT.FT_SERIE   = SD1.D1_SERIE "																				+ CRLF
 	cQuery += " 	AND SFT.FT_NFISCAL = SD1.D1_DOC "																				+ CRLF
 	cQuery += "		AND SFT.FT_CLIEFOR = SD1.D1_FORNECE " 																			+ CRLF
-	cQuery += "		AND SFT.FT_LOJA = SD1.D1_LOJA " 																				+ CRLF
-	cQuery += "		AND SFT.FT_ITEM = SD1.D1_ITEM " 																				+ CRLF
+	cQuery += "		AND SFT.FT_LOJA    = SD1.D1_LOJA " 																				+ CRLF
+	cQuery += "		AND SFT.FT_ITEM    = SD1.D1_ITEM " 																				+ CRLF
 	cQuery += "		AND SFT.FT_PRODUTO = SD1.D1_COD " 																				+ CRLF	
 	cQuery += "		AND SFT.D_E_L_E_T_ = ' ' "																						+ CRLF
 
@@ -691,10 +702,10 @@ Static Function zTmpRadio1()
 
 	cQuery += " GROUP BY 	D1_FILIAL, D1_COD, D1_DOC, D1_SERIE, D1_TES, D1_CF, D1_FORNECE, D1_LOJA, D1_EMISSAO, D1_DTDIGIT, " 		+ CRLF
 	cQuery += " D1_ITEM, F4_FINALID, F4_TEXTO, FT_CTIPI, FT_CSTPIS, FT_CSTCOF,  F4_ICM, F4_IPI, F4_CREDICM, F4_CREDIPI, F4_DUPLIC, "+ CRLF
-	cQuery += " B1_DESC, B1_XDESCL1, B1_GRUPO, B1_POSIPI, B1_CEST, B1_ORIGEM, B1_EX_NCM, B1_EX_NBM , "											+ CRLF
+	cQuery += " B1_DESC, B1_XDESCL1, B1_GRUPO, B1_POSIPI, B1_CEST, B1_ORIGEM, B1_EX_NCM, B1_EX_NBM , "								+ CRLF
 	cQuery += "	F1_ESPECIE, F1_CODNFE, F1_MENNOTA, F1_DOC, F1_SERIE, F1_STATUS, F1_TIPO, FT_CHVNFE,"								+ CRLF
 	cQuery += " FT_VALCONT, D1_CONTA, D1_ITEMCTA, D1_NFORI, D1_SERIORI, D1_VUNIT, D1_TOTAL, "										+ CRLF
-	cQuery += " D1_VALDESC, FT_CLASFIS, FT_BASERET, FT_ICMSRET, D1_DESCZFP, D1_DESCZFC,  "												+ CRLF
+	cQuery += " D1_VALDESC, FT_CLASFIS, FT_BASERET, FT_ICMSRET, D1_DESCZFP, D1_DESCZFC,  "											+ CRLF
 	cQuery += " F1_UFORITR, F1_MUORITR, F1_UFDESTR, F1_MUDESTR,  "																	+ CRLF
 	cQuery += " FT_BASEICM, FT_ALIQICM, FT_VALICM, FT_BRETPIS, FT_ARETPIS, FT_VRETPIS, FT_BRETCOF, FT_ARETCOF, FT_VRETCOF, "        + CRLF
 	cQuery += " FT_BASEIPI, FT_ALIQIPI, FT_VALIPI, " 																				+ CRLF
@@ -707,7 +718,7 @@ Static Function zTmpRadio1()
 	cQuery += " FT_BASEINS, FT_ALIQINS, D1_ABATINS, D1_AVLINSS, FT_VALINS, C7_NUM, FT_FORMUL, "										+ CRLF
 	cQuery += " D1_BASEISS, D1_ALIQISS, D1_ABATISS, D1_ABATMAT, D1_VALISS, FT_CODBCC, FT_INDNTFR, "									+ CRLF
 	cQuery += " D1_VALFRE, D1_DESPESA, D1_CUSTO, D1_SEGURO, D1_VALACRS, D1_II, FT_ICMSCOM, D1_TNATREC, D1_CONHEC,  "				+ CRLF
-	cQuery += " D1_PESO, FT_MVALPIS, FT_MVALCOF, W6_DTREG_D, W6_DI_NUM, YD_PER_II, VRK_OPCION, W9_TX_FOB "                          + CRLF
+	cQuery += " D1_PESO, FT_MVALPIS, FT_MVALCOF, W6_DTREG_D, W6_DI_NUM, VRK_OPCION, W9_TX_FOB "                          + CRLF
 
 	cQuery += " ORDER BY SD1.D1_FILIAL, SD1.D1_EMISSAO, SD1.D1_DOC, SD1.D1_SERIE, SD1.D1_ITEM, SD1.D1_FORNECE, SD1.D1_LOJA "		+ CRLF
 

--- a/SIGAFIS/Relatorio/ZFISR012.prw
+++ b/SIGAFIS/Relatorio/ZFISR012.prw
@@ -146,7 +146,19 @@ Static Function zRel0001(cArquivo)
 	cQuery += " FT_BASEINS, FT_ALIQINS, D1_ABATINS, D1_AVLINSS, FT_VALINS, C7_NUM, FT_FORMUL, "										+ CRLF
 	cQuery += " D1_BASEISS, D1_ALIQISS, D1_ABATISS, D1_ABATMAT, D1_VALISS, FT_CODBCC, FT_INDNTFR, "									+ CRLF
 	cQuery += " D1_VALFRE, D1_DESPESA, D1_CUSTO, D1_SEGURO, D1_VALACRS, D1_II, FT_ICMSCOM, D1_TNATREC, D1_CONHEC, "					+ CRLF
-	cQuery += " D1_PESO, FT_MVALPIS, FT_MVALCOF, W6_DTREG_D, W6_DI_NUM, YD_PER_II, VRK_OPCION, W9_TX_FOB, D1_CHASSI "							+ CRLF
+	cQuery += " D1_PESO, FT_MVALPIS, FT_MVALCOF, W6_DTREG_D, W6_DI_NUM, 
+		
+	cQuery += "( Select SYD.YD_PER_II from " + RetSqlName("SYD") + " SYD " + CRLF
+ 	cQuery += "	  where SYD.YD_FILIAL  = '" +  FWxFilial('SYD') + "' " + CRLF
+	cQuery += "		AND SYD.YD_TEC     = SB1.B1_POSIPI " + CRLF
+	cQuery += "		AND SYD.YD_EX_NCM  = SB1.B1_EX_NCM " + CRLF
+	cQuery += "		AND SYD.YD_EX_NBM  = SB1.B1_EX_NBM " + CRLF
+    cQuery += "		AND SYD.D_E_L_E_T_ = ' ' " + CRLF
+    cQuery += "		AND     ROWNUM     = 1 " + CRLF
+ 
+    cQuery += "		) as YD_PER_II,  " + CRLF
+
+	cQuery += " VRK_OPCION, W9_TX_FOB, D1_CHASSI " + CRLF
 
 	cQuery += " FROM " + RetSQLName('SD1') + " SD1 "																				+ CRLF
 
@@ -190,14 +202,14 @@ Static Function zRel0001(cArquivo)
 	cQuery += " 	ON SW9.W9_FILIAL = '" + FWxFilial('SW9') + "' "																	+ CRLF
 	cQuery += "		AND SW9.W9_HAWB = SD1.D1_CONHEC  "	 																			+ CRLF
 	cQuery += "     AND SW9.D_E_L_E_T_ = ' '   " 																					+ CRLF
-
+/*
 	cQuery += " LEFT JOIN " + RetSQLName("SYD") + " SYD  " 																			+ CRLF
 	cQuery += " 	ON SYD.YD_FILIAL = '" + FWxFilial('SYD') + "' "																	+ CRLF
 	cQuery += "		AND SYD.YD_TEC = SB1.B1_POSIPI "	 																			+ CRLF
 	cQuery += "		AND SYD.YD_EX_NCM = SB1.B1_EX_NCM  "	 																		+ CRLF
 	cQuery += "		AND SYD.YD_EX_NBM = SB1.B1_EX_NBM  "	 																		+ CRLF
 	cQuery += "     AND SYD.D_E_L_E_T_ = ' '   " 																					+ CRLF
-
+*/
 	cQuery += " LEFT JOIN " + RetSQLName("VVF") + " VVF "																			+ CRLF
 	cQuery += "		ON VVF.VVF_FILIAL = '" + FWxFilial('VVF') + "' "																+ CRLF
 	cQuery += " 	AND VVF.VVF_NUMNFI = SF1.F1_DOC "																				+ CRLF
@@ -238,13 +250,13 @@ Static Function zRel0001(cArquivo)
 	cQuery += "		AND SF3.F3_IDENTFT = SFT.FT_IDENTF3 " 																			+ CRLF
 	cQuery += "		AND SF3.D_E_L_E_T_ = ' ' "																						+ CRLF
 
-	cQuery += " WHERE SD1.D1_FILIAL BETWEEN '" + MV_PAR01 + "' AND '" + MV_PAR02 + "' " 											+ CRLF
-	cQuery += " 	AND SD1.D1_DOC BETWEEN '" + MV_PAR05 + "' AND '" + MV_PAR06 + "' " 												+ CRLF
-	cQuery += " 	AND SD1.D1_SERIE BETWEEN '" + MV_PAR07 + "' AND '" + MV_PAR08 + "' " 											+ CRLF
-	cQuery += " 	AND SD1.D1_FORNECE BETWEEN '" + MV_PAR09 + "' AND '" + MV_PAR10 + "' " 											+ CRLF
+	cQuery += " WHERE   SD1.D1_FILIAL  BETWEEN '" +       MV_PAR01   + "' AND '" +       MV_PAR02   + "' " 											+ CRLF
+	cQuery += " 	AND SD1.D1_DOC     BETWEEN '" +       MV_PAR05   + "' AND '" +       MV_PAR06   + "' " 												+ CRLF
+	cQuery += " 	AND SD1.D1_SERIE   BETWEEN '" +       MV_PAR07   + "' AND '" +       MV_PAR08   + "' " 											+ CRLF
+	cQuery += " 	AND SD1.D1_FORNECE BETWEEN '" +       MV_PAR09   + "' AND '" +       MV_PAR10   + "' " 											+ CRLF
 	cQuery += " 	AND SD1.D1_DTDIGIT BETWEEN '" + DToS( MV_PAR11 ) + "' AND '" + DToS( MV_PAR12 ) + "' " 							+ CRLF
 	cQuery += " 	AND SD1.D1_EMISSAO BETWEEN '" + DToS( MV_PAR13 ) + "' AND '" + DToS( MV_PAR14 ) + "' " 							+ CRLF
-	cQuery += " 	AND SD1.D1_COD BETWEEN '" + MV_PAR15 + "' AND '" + MV_PAR16 + "' " 												+ CRLF
+	cQuery += " 	AND SD1.D1_COD     BETWEEN '" +       MV_PAR15   + "' AND '" +       MV_PAR16   + "' " 												+ CRLF
 	cQuery += " 	AND SD1.D_E_L_E_T_ = ' ' "	 																					+ CRLF
 
 	If !Empty( MV_PAR17 )
@@ -261,7 +273,7 @@ Static Function zRel0001(cArquivo)
 
 	cQuery += " GROUP BY 	D1_FILIAL, D1_COD, D1_DOC, D1_SERIE, D1_TES, D1_CF, D1_FORNECE, D1_LOJA, D1_EMISSAO, D1_DTDIGIT, " 		+ CRLF
 	cQuery += " D1_ITEM, F4_FINALID, F4_TEXTO, FT_CTIPI, FT_CSTPIS, FT_CSTCOF,  F4_ICM, F4_IPI, F4_CREDICM, F4_CREDIPI, F4_DUPLIC, "+ CRLF
-	cQuery += " B1_DESC, B1_XDESCL1, B1_GRUPO, B1_POSIPI, B1_CEST, B1_ORIGEM, B1_EX_NCM, "											+ CRLF
+	cQuery += " B1_DESC, B1_XDESCL1, B1_GRUPO, B1_POSIPI, B1_CEST, B1_ORIGEM, B1_EX_NCM, B1_EX_NBM,"								+ CRLF
 	cQuery += "	F1_ESPECIE, F1_CODNFE, F1_MENNOTA, F1_DOC, F1_SERIE, F1_STATUS, F1_TIPO, FT_CHVNFE,"								+ CRLF
 	cQuery += " FT_VALCONT, D1_CONTA, D1_ITEMCTA, D1_NFORI, D1_SERIORI, D1_VUNIT, D1_TOTAL, "										+ CRLF
 	cQuery += " D1_DESC, FT_CLASFIS, FT_BASERET, FT_ICMSRET, D1_DESCZFP, D1_DESCZFC,  "												+ CRLF
@@ -277,7 +289,7 @@ Static Function zRel0001(cArquivo)
 	cQuery += " FT_BASEINS, FT_ALIQINS, D1_ABATINS, D1_AVLINSS, FT_VALINS, C7_NUM, FT_FORMUL, "										+ CRLF
 	cQuery += " D1_BASEISS, D1_ALIQISS, D1_ABATISS, D1_ABATMAT, D1_VALISS, FT_CODBCC, FT_INDNTFR, "									+ CRLF
 	cQuery += " D1_VALFRE, D1_DESPESA, D1_CUSTO, D1_SEGURO, D1_VALACRS, D1_II, FT_ICMSCOM, D1_TNATREC, D1_CONHEC,  "				+ CRLF
-	cQuery += " D1_PESO, FT_MVALPIS, FT_MVALCOF, W6_DTREG_D, W6_DI_NUM, YD_PER_II, VRK_OPCION, W9_TX_FOB, D1_CHASSI "							+ CRLF
+	cQuery += " D1_PESO, FT_MVALPIS, FT_MVALCOF, W6_DTREG_D, W6_DI_NUM, VRK_OPCION, W9_TX_FOB, D1_CHASSI "							+ CRLF
 
 	cQuery += " ORDER BY SD1.D1_FILIAL, SD1.D1_EMISSAO, SD1.D1_DOC, SD1.D1_SERIE, SD1.D1_ITEM, SD1.D1_FORNECE, SD1.D1_LOJA "		+ CRLF
 

--- a/SIGAFIS/Relatorio/ZFISR015.prw
+++ b/SIGAFIS/Relatorio/ZFISR015.prw
@@ -146,7 +146,19 @@ Static Function zRel0001(cArquivo)
 	cQuery += " FT_BASEINS, FT_ALIQINS, D1_ABATINS, D1_AVLINSS, FT_VALINS, C7_NUM, FT_FORMUL, "										+ CRLF
 	cQuery += " D1_BASEISS, D1_ALIQISS, D1_ABATISS, D1_ABATMAT, D1_VALISS, FT_CODBCC, FT_INDNTFR, "									+ CRLF
 	cQuery += " D1_VALFRE, D1_DESPESA, D1_CUSTO, D1_SEGURO, D1_VALACRS, D1_II, FT_ICMSCOM, D1_TNATREC, D1_CONHEC, "					+ CRLF
-	cQuery += " D1_PESO, FT_MVALPIS, FT_MVALCOF, W6_DTREG_D, W6_DI_NUM, YD_PER_II, VRK_OPCION, W9_TX_FOB "							+ CRLF
+	cQuery += " D1_PESO, FT_MVALPIS, FT_MVALCOF, W6_DTREG_D, W6_DI_NUM, 
+		
+	cQuery += "( Select SYD.YD_PER_II from " + RetSqlName("SYD") + " SYD " + CRLF
+ 	cQuery += "	  where SYD.YD_FILIAL  = '" +  FWxFilial('SYD') + "' " + CRLF
+	cQuery += "		AND SYD.YD_TEC     = SB1.B1_POSIPI " + CRLF
+	cQuery += "		AND SYD.YD_EX_NCM  = SB1.B1_EX_NCM " + CRLF
+	cQuery += "		AND SYD.YD_EX_NBM  = SB1.B1_EX_NBM " + CRLF
+    cQuery += "		AND SYD.D_E_L_E_T_ = ' ' " + CRLF
+    cQuery += "		AND     ROWNUM     = 1 " + CRLF
+ 
+    cQuery += "		) as YD_PER_II,  " + CRLF
+
+	cQuery += " VRK_OPCION, W9_TX_FOB "							+ CRLF
 
 	cQuery += " FROM " + RetSQLName('SD1') + " SD1 "																				+ CRLF
 
@@ -190,14 +202,14 @@ Static Function zRel0001(cArquivo)
 	cQuery += " 	ON SW9.W9_FILIAL = '" + FWxFilial('SW9') + "' "																	+ CRLF
 	cQuery += "		AND SW9.W9_HAWB = SD1.D1_CONHEC  "	 																			+ CRLF
 	cQuery += "     AND SW9.D_E_L_E_T_ = ' '   " 																					+ CRLF
-
+/*
 	cQuery += " LEFT JOIN " + RetSQLName("SYD") + " SYD  " 																			+ CRLF
 	cQuery += " 	ON SYD.YD_FILIAL = '" + FWxFilial('SYD') + "' "																	+ CRLF
 	cQuery += "		AND SYD.YD_TEC = SB1.B1_POSIPI "	 																			+ CRLF
 	cQuery += "		AND SYD.YD_EX_NCM = SB1.B1_EX_NCM  "	 																		+ CRLF
 	cQuery += "		AND SYD.YD_EX_NBM = SB1.B1_EX_NBM  "	 																		+ CRLF
 	cQuery += "     AND SYD.D_E_L_E_T_ = ' '   " 																					+ CRLF
-
+*/
 	cQuery += " LEFT JOIN " + RetSQLName("VVF") + " VVF "																			+ CRLF
 	cQuery += "		ON VVF.VVF_FILIAL = '" + FWxFilial('VVF') + "' "																+ CRLF
 	cQuery += " 	AND VVF.VVF_NUMNFI = SF1.F1_DOC "																				+ CRLF
@@ -257,7 +269,7 @@ Static Function zRel0001(cArquivo)
 
 	cQuery += " GROUP BY 	D1_FILIAL, D1_COD, D1_DOC, D1_SERIE, D1_TES, D1_CF, D1_FORNECE, D1_LOJA, D1_EMISSAO, D1_DTDIGIT, " 		+ CRLF
 	cQuery += " D1_ITEM, F4_FINALID, F4_TEXTO, FT_CTIPI, FT_CSTPIS, FT_CSTCOF,  F4_ICM, F4_IPI, F4_CREDICM, F4_CREDIPI, F4_DUPLIC, "+ CRLF
-	cQuery += " B1_DESC, B1_XDESCL1, B1_GRUPO, B1_POSIPI, B1_CEST, B1_ORIGEM, B1_EX_NCM, "											+ CRLF
+	cQuery += " B1_DESC, B1_XDESCL1, B1_GRUPO, B1_POSIPI, B1_CEST, B1_ORIGEM, B1_EX_NCM, B1_EX_NBM, "											+ CRLF
 	cQuery += "	F1_ESPECIE, F1_CODNFE, F1_MENNOTA, F1_DOC, F1_SERIE, F1_STATUS, F1_TIPO, FT_CHVNFE,"								+ CRLF
 	cQuery += " FT_VALCONT, D1_CONTA, D1_ITEMCTA, D1_NFORI, D1_SERIORI, D1_VUNIT, D1_TOTAL, "										+ CRLF
 	cQuery += " D1_DESC, FT_CLASFIS, FT_BASERET, FT_ICMSRET, D1_DESCZFP, D1_DESCZFC,  "												+ CRLF
@@ -273,7 +285,7 @@ Static Function zRel0001(cArquivo)
 	cQuery += " FT_BASEINS, FT_ALIQINS, D1_ABATINS, D1_AVLINSS, FT_VALINS, C7_NUM, FT_FORMUL, "										+ CRLF
 	cQuery += " D1_BASEISS, D1_ALIQISS, D1_ABATISS, D1_ABATMAT, D1_VALISS, FT_CODBCC, FT_INDNTFR, "									+ CRLF
 	cQuery += " D1_VALFRE, D1_DESPESA, D1_CUSTO, D1_SEGURO, D1_VALACRS, D1_II, FT_ICMSCOM, D1_TNATREC, D1_CONHEC,  "				+ CRLF
-	cQuery += " D1_PESO, FT_MVALPIS, FT_MVALCOF, W6_DTREG_D, W6_DI_NUM, YD_PER_II, VRK_OPCION, W9_TX_FOB "							+ CRLF
+	cQuery += " D1_PESO, FT_MVALPIS, FT_MVALCOF, W6_DTREG_D, W6_DI_NUM, VRK_OPCION, W9_TX_FOB "							+ CRLF
 
 	cQuery += " ORDER BY SD1.D1_FILIAL, SD1.D1_EMISSAO, SD1.D1_DOC, SD1.D1_SERIE, SD1.D1_ITEM, SD1.D1_FORNECE, SD1.D1_LOJA "		+ CRLF
 


### PR DESCRIPTION
Foi ajustado a Query do documento de entrada, pois o relacionamento do NCM com o Produto estava provocando a duplicação dos dados no relatório.

**Termo de Entrega**
[GAP126-Está trazendo itens ou duplicando os itens com isso alterando o valor dá o valor da nota.pdf](https://github.com/Caoa-Montadora-de-Veiculos-Ltda/Protheus/files/14141009/GAP126-Esta.trazendo.itens.ou.duplicando.os.itens.com.isso.alterando.o.valor.da.o.valor.da.nota.pdf)