### PR TITLE
CHG0033301 | COM007 | Retirada do botão "Alterar Comprador"

### DIFF
--- a/SIGACOM/Função/ZCOMF032.prw
+++ b/SIGACOM/Função/ZCOMF032.prw
@@ -179,7 +179,7 @@ Private _cRot       := "ZCOMF032"
             oBrowse:SetColumns(ZCOMF032T("TR_SOLICIT"     ,"Solicitante" ,07 ,"@!"   ,1,025,0))
           
             oBrowse:AddButton("Recusar Item..."	        , { || ZCOMF032G()},,,, .F., 2 )
-            oBrowse:AddButton("Alterar Comprador..."	, { || ZCOMF032C()},,,, .F., 2 )
+            //oBrowse:AddButton("Alterar Comprador..."	, { || ZCOMF032C()},,,, .F., 2 ) - LFT 07/02/2024 - retirado a funcionalidade conforme chamado INC0106792
                      
             oBrowse:bAllMark := { || ZCOMF032I(oBrowse:Mark(),lMarcar := !lMarcar ), oBrowse:Refresh(.T.)  }
             oBrowse:Activate()
@@ -392,7 +392,8 @@ Local OObs
 Local cMotivo       := ""
 Local aMotivo       := {}
 Local oMotivo   
-Local y 
+Local y
+Local i 
 Local aSizeAut      := MsAdvSize(,.F.,400)
 Private aRadio      := {}
 Private _aObsQ      := {}


### PR DESCRIPTION
Alterado o fonte ZCOMF032, removendo o botão de “Alterar Comprador”, pois o mesmo não é utilizado.

**Termo de Entrega**

[GAP123 -Erro na alteração do comprador na SC - tirar a funcionalidade da rotina .pdf](https://github.com/Caoa-Montadora-de-Veiculos-Ltda/Protheus/files/14210423/GAP123.-Erro.na.alteracao.do.comprador.na.SC.-.tirar.a.funcionalidade.da.rotina.pdf)
