### PR TITLE
CHG0033455 | Integração | RgLog 002.001 | Ajuste na função de conversão da data

### DIFF
--- a/Integracoes/RgLog - SILT/ZWSR013.PRW
+++ b/Integracoes/RgLog - SILT/ZWSR013.PRW
@@ -98,9 +98,9 @@ User Function ZWSR013()
                             SubStr( (_cAlias)->F2_EMISSAO ,5 ,2 ) + '-' +;
                             SubStr( (_cAlias)->F2_EMISSAO ,7 ,2 )
 
-			cDataBase := 	Substr(DTOC(dDatabase),7,4) +'-'+;
-							Substr(DTOC(dDatabase),4,2) +'-'+;
-							Substr(DTOC(dDatabase),1,2)
+			cDataBase := 	Substr(DTOS(dDatabase),1,4) +'-'+;
+							Substr(DTOS(dDatabase),5,2) +'-'+;
+							Substr(DTOS(dDatabase),7,2)
             
 			FreeObj(oJsConFat)                     
 			oJsConFat := JsonObject():new()


### PR DESCRIPTION
Alterado a função que converte a data DTOC para DTOS, pois quando é executado via Job a data é convertida para DD/MM/AA ao invés de DD/MM/AAAA como é via manual.
Pois a Função DTOS sempre traz a data no formato AAAAMMDD.

De:
cDataBase := 	Substr(DTOC(dDatabase),7,4) +'-'+;
			Substr(DTOC(dDatabase),4,2) +'-'+;
			Substr(DTOC(dDatabase),1,2)
Para: 
cDataBase := 	Substr(DTOS(dDatabase),1,4) +'-'+;
			Substr(DTOS(dDatabase),5,2) +'-'+;
			Substr(DTOS(dDatabase),7,2)


