### PR TITLE
GAP165 | Tratativa na importação do CSV da solicitação de compras para procurar a amarração Produto x Fornecedor desbloqueada.

### DIFF
--- a/Ponto de Entrada/GRVMT112_PE.prw
+++ b/Ponto de Entrada/GRVMT112_PE.prw
@@ -17,7 +17,6 @@ User Function GRVMT112()
 	Local aAreaSW1	:= SW1->(GetArea())
 	Local aAreaSC1	:= SC1->(GetArea())
 
-
 	SA5->(DbSetOrder(1))
 	SA5->(DbSeek(xFilial("SA5") + SC1->(C1_FORNECE + C1_LOJA + C1_PRODUTO)))
 

--- a/SIGACOM/Função/IMPCSVSC.PRW
+++ b/SIGACOM/Função/IMPCSVSC.PRW
@@ -83,6 +83,7 @@ USER FUNCTION IMPCSV()
 
 	cFabr := cFabrLoj := cxSCDe := cxSCAte := ""
 	Aadd(aArqArq,{.F.,""})
+	
 	DEFINE MSDIALOG oDLG TITLE "Importacao de Arquivos CSV" FROM 0,0 TO 430, 680 OF oMainWnd PIXEL
 	@ 040,007 SAY "Tipo Importação" PIXEL OF oDLG
 	@ 050,007 MSGET cTipoImp PICTURE cPICTA VALID(FVAL("TIPOIMP")) F3 "ZZ8" SIZE 035,08 PIXEL OF oDLG


### PR DESCRIPTION
-Tratativa no fonte IMPCSVSC.PRW: A rotina da importação da SC passa a validar a amarração Produto x Fornecedor que estão bloqueados e gerando log em tela para tratativa e correção dos itens;
-Tratativa no PE GRVMT112_PE.prw: Valida a gravação dos fabricantes na gravação da SC, somente os registros da amarração Produto x Fornecedor desbloqueado que será válido.