### PR TITLE
CHG0033573 | EIC009.001 | Inclusao IPI no Cadastro de Produto

### DIFF
--- a/SIGAEIC/Funcao/ZEICF006.prw
+++ b/SIGAEIC/Funcao/ZEICF006.prw
@@ -54,6 +54,7 @@ Static Function zGetItens()
     cmd += CRLF +  " - Retem PIS."       
     cmd += CRLF +  " - Retem COFINS."    
     cmd += CRLF +  " - Grupo tributário."
+    cmd += CRLF +  " - IPI."
     cmd += CRLF + "Deseja atualizar esses campos nos produtos ? "
     
     If MsgYesNo(cmd, "ZEICF006") = .F.
@@ -87,6 +88,7 @@ Static Function zProcessa(aRegs)
         oMdl:SetValue("SB1MASTER", "B1_PIS"   , SYD->YD_XRETPIS)
         oMdl:SetValue("SB1MASTER", "B1_COFINS", SYD->YD_XRETCOF)
         oMdl:SetValue("SB1MASTER", "B1_GRTRIB", SYD->YD_XGRPTRI)
+        oMdl:SetValue("SB1MASTER", "B1_IPI"   , SYD->YD_PER_IPI)
 
         If oMdl:VldData()
             oMdl:CommitData()


### PR DESCRIPTION
GAP171 | Inclusão da aliquota de IPI no Cadastro de Produtos via gatilho - ZEICF006,
 para auxiliar e evitar erro no cadastramento.

Descrição: Divergência no cadastramento do IPI no Produto.

Recurso CAOA

