### PR TITLE
CHG0033578 | ACD001.002 | Error log no acd de madrugada

### DIFF
--- a/SIGAACD/Função/ZACDF001.prw
+++ b/SIGAACD/Função/ZACDF001.prw
@@ -185,7 +185,7 @@ User Function ZACDF001( cOriUnitz )   // vtdebug
 	
 	TcQuery cmd new alias (cTb)
 	
-	IF ELAPTIME( (cTb)->ZJ_HRLEITU , fTimer() ) <= "00:30:00" .AND. Dtos(Date()) == (cTb)->ZJ_DATE
+	IF ELAPTIME( (cTb)->ZJ_HRLEITU , fTimer() ) <= "00:30:00" .AND. Dtos(Date()) == (cTb)->ZJ_DATA
 		VTAlert( "Unitizador: " + AllTrim(cOriUnitz) + " já se encontra na fila", "Erro", .T.)
 		Loop
 	ENDIF


### PR DESCRIPTION
Fonte: ZACDF001
Erro: Toda madrugada por volta de 1h os coletores estavam caindo.
Solução: Ajustado o fonte pois estava referenciando o campo errado na query