### PR TITLE
CHG0033587 | GFE003 | Errorlog no calculo de frete

### DIFF
--- a/Ponto de Entrada/GFEXFB18_PE.PRW
+++ b/Ponto de Entrada/GFEXFB18_PE.PRW
@@ -7,8 +7,10 @@ PE p/ chamada da função
 @version 1.0
 /*/
 User Function GFEXFB18()
-	Local _cEmp	   := FWCodEmp()
-
+	Local _cEmp	  := FWCodEmp()
+	Local nValor  := ParamIxb[1]
+    //Local cComp  := ParamIxb[2]
+	
 	If _cEmp == "2020" //Executa o p.e. Barueri
 
       If Findfunction("U_ZGFEF007")


### PR DESCRIPTION
Foi declarado a variável nValor e atribuído o conteúdo da variável ParamIxb[1] que é o valor original do frete.