### PR TITLE
CHG0033647 | PEC001.009 | Remover a trava da empresa 02 | Franco da Rocha para rodar a marca Hyundai.

### DIFF
--- a/SIGAPEC/Funcao/ZPECF008.PRW
+++ b/SIGAPEC/Funcao/ZPECF008.PRW
@@ -140,12 +140,7 @@ User Function ZPECF008()
 		_aMensAglu	:= {}
 		_cObsPrc    := ""
 
-		If ( AllTrim(FwCodEmp()) == "2020" .And. AllTrim(FwFilial()) == "2001" ) //Empresa 02-Franco da Rocha
-			If AllTrim(_aRet[10]) == "HYU" //Não Pode Hyundai
-				Help( , ,OemToAnsi(STR0028),,"Marca HYU bloqueada na empresa 02 | Franco da Rocha",4,1) //Atenção / Necessário informar os parâmetros 
-				Break 
-			EndIf
-		ElseIf ( AllTrim(FwCodEmp()) == "9010" .And. AllTrim(FwFilial()) == "HAD1" ) //90- HMB
+		If ( AllTrim(FwCodEmp()) == "9010" .And. AllTrim(FwFilial()) == "HAD1" ) //90- HMB
 			If ( AllTrim(_aRet[10]) == "CHE" .Or. AllTrim(_aRet[10]) == "SBR" )
 				Help( , ,OemToAnsi(STR0028),,"Marca CHE/SBR bloqueada na empresa 90 | HMB",4,1) //Atenção / Necessário informar os parâmetros 
 				Break 


### PR DESCRIPTION

Foram bloqueados os processos Hyundai na Empresa 02, porém existe a necessidade de tratar acertos de importações e o faturamento para RG de processos de reclamação que estavam parados por conta do corte da operação.
Desta forma foi retirado a trava da empresa 02 Franco da Rocha para rodar a marca Hyundai.
