### PR TITLE
EICDI500.001 | Campo D1_XCASE em branco quando o campo W8_XCASE estiver em branco

### DIFF
--- a/Ponto de Entrada/EICDI500_PE.PRW
+++ b/Ponto de Entrada/EICDI500_PE.PRW
@@ -181,6 +181,11 @@ ElseIf cParam == "TELA_TOTAIS_DESP"
 	EndDo
 
 	TRB->(DbGoTop())
+
+ElseIf cParam == "INV_CARREGA_SW8
+	Work_SW8->W8_XCASE:= SW8->W8_XCASE
+	Work_SW8->W8_XLOTE:= SW8->W8_XLOTE
+	Work_SW8->W8_XCONT:= SW8->W8_XCONT
 EndIf
 
 Return lRet


### PR DESCRIPTION
GAP209 - Alteração no fonte EICDI500_PE.prw , adicionado o PE "INV_CARREGA_SW8"  para gravar campo customizado W8_XCASE, W8_XLOTE e W8_XCONT