### PR TITLE
EIC003.006 | Integração Contas a Pagar Z7_SERORI="EIC"

### DIFF
--- a/Integracoes/SAP/ZGENSAP.prw
+++ b/Integracoes/SAP/ZGENSAP.prw
@@ -839,8 +839,15 @@ User Function ZF11GENSAP(cxFil,cTab,cIndice,cChave,nOperPro,nOperSAP,cXMLSZ7,cSt
         // tratamento para quando vier status "N" no quinto elemento do array adadosori,
         // neste caso indica que o registro de exclusao nao deve ser processado, pois o registro de inclusao ainda nao foi
         // enviado, e tambem o registro de inclusao nao deve ser processado
-        If nOperSAP == 2 .and. Len(aDadosOri) > 1 .and. aDadosOri[5] == "N" .and. !Empty(aDadosOri[6])
+        If nOperSAP == 1 .and. Len(aDadosOri) > 1 .and. aDadosOri[5] == "N" .and. !Empty(aDadosOri[6])
             lNaoProcEnvio := .T.
+            SZ7->Z7_XSTATUS := "N"
+            nRecStatusExc := SZ7->(Recno())
+        Endif
+
+        // Adicionado por Cintia Araujo em 05/07/24 - INC0112050 - gerar Z7_XSTATUS = 'N' quando Z7_SERORI = 'EIC' para nao integrar SAP
+        If SZ7->Z7_SERORI = 'EIC' 
+            lNaoProcEnvio := .F.
             SZ7->Z7_XSTATUS := "N"
             nRecStatusExc := SZ7->(Recno())
         Endif


### PR DESCRIPTION
GAP211 - Integração Contas a Pagar Z7_SERORI="EIC"

Os títulos provenientes do módulo de importação (contas a pagar) não é para serem integrados no SAP.

Ajustado o fonte para que gera os registros na tabela SZ7 com o status de não integrado, para que não seja lido pelo job de integração.

Fonte: ZGENSAP.prw