### PR TITLE
FIS003.010 | Extração de Relatório não esta extraindo o CST ICMS e CST IPI

### DIFF
--- a/Ponto de Entrada/COMCOLSD.prw
+++ b/Ponto de Entrada/COMCOLSD.prw
@@ -1,0 +1,41 @@
+#Include "Totvs.ch"
+
+//-------------------------------------------------------------------
+/* {Protheus.doc} COMCOLSD
+	Ponto de Entrada Monitor Totvs Colaboração. Após gravar SDS e SDT.
+
+	@author    Cintia Araujo
+	@since     23/07/2024
+
+*/
+//-------------------------------------------------------------------
+User Function COMCOLSD()
+	//Local _aCols   := ParamIXB[1]
+	//Local _aHeader := ParamIXB[2]
+	Local aAreaX   := GetArea( ) 
+	Local aAreaSB1 := SB1->( GetArea( ) )
+	Local aAreaSF4 := Sf4->( GetArea( ) ) 
+	   
+	SB1->(dBSetOrder(1)) 
+	SF4->(dBSetOrder(1))
+	SDT->(dBSetOrder(1))
+	If SDT->(MsSeek(xFilial("SDT")+SDS->DS_CNPJ+SDS->DS_FORNEC+SDS->DS_LOJA+SDS->DS_DOC+SDS->DS_SERIE))
+		Do While (SDS->DS_CNPJ == SDT->DT_CNPJ) .And. (SDS->DS_FORNEC == SDT->DT_FORNEC) .And. ;
+				 (SDS->DS_LOJA == SDT->DT_LOJA) .And. (SDS->DS_DOC == SDT->DT_DOC)
+			If !Empty(SDT->DT_TES) .And. Len(AllTrim(SDT->DT_CLASFIS)) < 3
+				SB1->( MsSeek(xFilial("SB1")+SDT->DT_COD) )
+				SF4->( MsSeek(xFilial("SF4")+SDT->DT_TES) )
+
+				RecLock("SDT",.F.)
+				SDT->DT_CLASFIS := SubStr(SB1->B1_ORIGEM,1,1)+SF4->F4_SITTRIB
+				MsUnLock()
+			EndIF
+			SDT->( DbSkip() )
+		EndDo
+	EndIf
+
+ 	RestArea(aAreaSF4)
+ 	RestArea(aAreaSB1)
+	RestArea(aAreaX)
+ 
+Return

--- a/Ponto de Entrada/M103PCIT.prw
+++ b/Ponto de Entrada/M103PCIT.prw
@@ -1,0 +1,41 @@
+#Include "Totvs.ch"
+
+//-------------------------------------------------------------------
+/* {Protheus.doc} M103PCIT
+	Ponto de Entrada Doc. Entrada - Manipulacao aCol apos vinculo com pedido
+
+	@author    Cintia Araujo
+	@since     23/07/2024
+
+*/
+//-------------------------------------------------------------------
+User Function M103PCIT()
+	Local nPosPrd     := aScan(aHeader, {|x| AllTrim(x[2]) == "D1_COD"   })
+	Local nPosTES     := aScan(aHeader, {|x| AllTrim(x[2]) == "D1_TES"   })
+	Local nPosPc      := aScan(aHeader, {|x| AllTrim(x[2]) == "D1_PEDIDO"})
+	Local nPosItPc    := aScan(aHeader, {|x| AllTrim(x[2]) == "D1_ITEMPC"})
+	Local aAreaX      := GetArea( )
+	Local aAreaSB1    := SB1->( GetArea( ) )
+	Local nPosBkp     := n
+	Local cReadVarBkp := __ReadVar
+	Local nPosX       := 0
+ 	 
+	SB1->( dbSetOrder(1) )
+ 	For nPosX := 1 To Len(aCols)
+		If AllTrim(aCols[nPosX, nPosPc]) == AllTrim(SC7->C7_NUM) .And. aCols[nPosX, nPosItPc] == AllTrim(SC7->C7_ITEM)
+			SB1->( DbSeek(FWxFilial("SB1")+PadR(aCols[nPosX, nPosPrd], TamSx3('B1_COD') [1])) )
+			n         := nPosX
+			__ReadVar := PADR("D1_TES", 10)
+			&("M->"+__ReadVar) :=  aCols[nPosX, nPosTES]
+			&(GetSx3Cache(__ReadVar, "X3_VALID"))
+			RunTrigger(2, n, Nil,, __ReadVar) 
+	 	EndIf
+ 	Next nPosX
+ 
+	n         := nPosBkp
+	__ReadVar := cReadVarBkp
+
+	RestArea(aAreaSB1)
+	RestArea(aAreaX)
+
+Return 


### PR DESCRIPTION
GAP226-FIS003.010 | Extração de Relatório não esta extraindo o CST ICMS e CST IPI](https://github.com/Caoa-Montadora-de-Veiculos-Ltda/Protheus/pull/565#top)
O Relatório SAFX08 é um espelho dos livros Fiscais, a informação de Situação Tributária, não está sendo preenchida em alguns itens da Nota e consequentemente não é levada para o Livro Fiscal.

Conforme testes de validação isso ocorre quando há quebra de itens ao selecionar Pedido de Vendas, na inclusão da Nota, sendo pelo Documento de entrada ou pela Rotina de Monitor do TOTVS Colaboração.

Para que o campo Situação Tributária na NF, seja preenchido foram  desenvolvidos os Pontos de entrada M103PCIT.prw e COMCOLSD.prw, também criados gatilhos no campo DT_CLASFIS e DT_TES
, e também na extração das SAFX08 para carga. 
[Gatilho_SX7_SDT.zip](https://github.com/user-attachments/files/16432212/Gatilho_SX7_SDT.zip)


