### PR TITLE
GAP231 | Correção da ZFM - Desoneração - tag indDeduzDeson

### DIFF
--- a/SIGAFAT/Função/danfeii.prw
+++ b/SIGAFAT/Função/danfeii.prw
@@ -3,7 +3,7 @@
 #INCLUDE "COLORS.CH"
 #INCLUDE "RPTDEF.CH"
 #INCLUDE "FWPrintSetup.ch" 
- 
+  
 #DEFINE IMP_SPOOL 2
 #DEFINE VBOX       080
 #DEFINE VSPACE     008
@@ -42,10 +42,10 @@
 ±±ÀÄÄÄÄÄÄÄÄÄÄÁÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÁÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÙ±±
 ±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±±
 ßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßß
-/*/
+/*/ 
 User Function PrtNfeSef(cIdEnt, cVal1		, cVal2		, oDanfe,;
 						oSetup, cFilePrint	, lIsLoja	, nTipo )
-
+ 
 Local aArea     := GetArea()
 Local lExistNfe := .F.
 Local lPergunte	:= .T.
@@ -1492,7 +1492,7 @@ EndIf
 //ÚÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ¿
 //³Calculo do Imposto                                                      ³
 //ÀÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÙ
-aTotais := {"","","","","","","","","","",""}
+aTotais := {"","","","","","","","","","","",""}
 aTotais[01] := Transform(Val(oTotal:_ICMSTOT:_vBC:TEXT),"@e 9,999,999,999,999.99")
 aTotais[02] := Transform(Val(oTotal:_ICMSTOT:_vICMS:TEXT),"@e 9,999,999,999,999.99")
 aTotais[03] := Transform(Val(oTotal:_ICMSTOT:_vBCST:TEXT),"@e 9,999,999,999,999.99")

--- a/SIGAFAT/Função/nfesefaz.prw
+++ b/SIGAFAT/Função/nfesefaz.prw
@@ -551,7 +551,7 @@ Else
 	lPe01Nfe := ExistBlock("ZCSP_NFESEFAZ")
 EndIf
 //***********************************************
-
+ 
 If FunName() == "SPEDNFSE"
 	DEFAULT cTipo   := PARAMIXB[1]
 	DEFAULT cSerie  := PARAMIXB[3]
@@ -627,8 +627,8 @@ IF Alltrim(GetNewPar("MV_CAMPBAR",""))  <>  ""
 			cBarTrib 	:= aCampBar[2]
 		Endif
 	Endif
-Endif 
-
+Endif  
+ 
 If cTipo == "1"
 	//旼컴컴컴컴컴컴컴컴컴컴컴컴컴컴컴컴컴컴컴컴컴컴컴컴컴컴컴컴컴컴컴컴컴컴컴커
 	//쿣erifica se existem mais de um cupom relacionado na nota sobre cupom    �
@@ -11132,7 +11132,7 @@ Static Function LeiTransp (nPos,aProd,aNota)
 
 Local nAliq := 0
 Local aAreaSD2 := SD2->( GetArea() )
-local cFilial	:= xFilial("SD2")
+//local _cFilial	:= ' '
 local cDoc		:= iif(len(aNota)>=2,PadR(aNota[2],TamSx3("D2_DOC")[1]),"")
 local cSerie	:= iif(len(aNota)>=1,PadR(aNota[1],TamSx3("D2_SERIE")[1]),"")
 local cCliente	:= iif(len(aNota)>=7,PadR(aNota[7],TamSx3("D2_CLIENTE")[1]),"")
@@ -11144,10 +11144,12 @@ Default nPos	:= 30
 Default aProd :={}
 Default aNota :={}
 
+//_cFilial	:= FwFilial("SD2")
+
 DbSelectArea("SD2")
 DbSetOrder(3) //D2_FILIAL, D2_DOC, D2_SERIE, D2_CLIENTE, D2_LOJA, D2_COD, D2_ITEM
 
-If len(aNota) > 1 .and. MsSeek(cFilial+cDoc+cSerie+cCliente+cLoja+cCodigo+cItem)
+If len(aNota) > 1 .and. MsSeek(FwFilial("SD2")+cDoc+cSerie+cCliente+cLoja+cCodigo+cItem)
 	nAliq := aProd[nPos] /  (SD2->D2_VALBRUT + SD2->D2_DESCON)
 Endif	
 


### PR DESCRIPTION
1 - Copiar RPO Produção para base a ser executada
2 - Criar parametro : MV_NT23004
Descrição: Parâmetro temporário para controle de datas da NT 2023.004.
Tipo: 1-Caracter
Cont. Por: 01/07/2024

3 - Aplicar Pacote : 24-07-18_ATUALIZACAO_12.1.2310_TSS_PROTHEUS_EXPEDICAO_CONTINUA
[24-07-18_ATUALIZACAO_12.1.2310_TSS_PROTHEUS_EXPEDICAO_CONTINUA.ZIP](https://github.com/user-attachments/files/16459762/24-07-18_ATUALIZACAO_12.1.2310_TSS_PROTHEUS_EXPEDICAO_CONTINUA.ZIP)

4 - Aplicar Pacote : PACOTE_DE_CORRECAO_18797903_DSERTSS1-22661_12.1.2310
[PACOTE_DE_CORRECAO_18797903_DSERTSS1-22661_12.1.2310.ZIP](https://github.com/user-attachments/files/16459764/PACOTE_DE_CORRECAO_18797903_DSERTSS1-22661_12.1.2310.ZIP)

5 - Recompilar fontes Danfeii.prw e NfeSefaz.prw