### PR TITLE
GAP233 | Correção da tag xped do XML para faturamento dos HRs

### DIFF
--- a/SIGAFAT/Função/nfesefaz.prw
+++ b/SIGAFAT/Função/nfesefaz.prw
@@ -33,7 +33,6 @@ static lCDVLanc		:= nil
 ßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßß
 /*/
 User Function XmlNfeSef(cTipo,cSerie,cNota,cClieFor,cLoja,cNotaOri,cSerieOri)
- 
 //Declaração de Arrays
 Local aNota     	:= {}
 Local aDupl     	:= {}


### PR DESCRIPTION
GAP233 | Correção da tag xped do XML para faturamento dos HRs