### PR TITLE
GAP241 | Solução para que o grupo tributário não seja trocado

### DIFF
--- a/Ponto de Entrada/PEDVEI011_PE.prw
+++ b/Ponto de Entrada/PEDVEI011_PE.prw
@@ -12,9 +12,9 @@
 */
 
 User Function PEDVEI011()
-
+  
 	Local nPosTES
-
+ 
 	//alert("PEDVEI011")
 	Conout("PEDVEI011")
 	Conout("PEDVEI011 - C6_XBASST " + cValToChar(VVA->VVA_XBASST))
@@ -22,9 +22,11 @@ User Function PEDVEI011()
 	aAdd(aCabPV,  {"C5_XMENSER" ,E_MSMM(VV0->VV0_OBSMNF)   ,Nil}) 
 	aAdd(aCabPV,  {"C5_CLIREM"  , VV0->VV0_CLIRET 		   ,Nil}) 
 	aAdd(aCabPV,  {"C5_LOJAREM" , VV0->VV0_LOJRET 		   ,Nil}) 
+	aAdd(aCabPV,  {"C5_TIPOCLI" , VRJ->VRJ_TIPOCL 		   ,Nil}) // Adicionado Por Cintia Araujo - 08/2024 para trazer informação do Pedido Montadora e considerar a Exceçao Fiscal conforme Tipo de Pedido
+
 	AADD(aIteTPv, {"C6_NUMSERI" , VVA->VVA_CHASSI          ,NIL})
 	AADD(aIteTPv, {"C6_XBASST"  , VVA->VVA_XBASST          ,NIL})
-	AADD(aIteTPv, {"C6_QTDLIB"  , 1                        ,NIL}) // Para correÃ§Ã£o de Erro do PadrÃ£o Protheus
+	AADD(aIteTPv, {"C6_QTDLIB"  , 1                        ,NIL}) // Para correca de Erro do Padrao Protheus
 	AADD(aIteTPv, {"C6_XBASPI"  , VVA->VVA_XBASPI          ,NIL})
 	AADD(aIteTPv, {"C6_XBASCO"  , VVA->VVA_XBASCO          ,NIL})
 	AADD(aIteTPv, {"C6_XBASIP"  , VVA->VVA_XBASIP          ,NIL})


### PR DESCRIPTION
Realizada instrução para criação de uma exceção fiscal para compor o calculo, sempre considerando Grupo do Produto, UF do Cliente e Tipo do Pedido (exemplo: revendedor ou consumidor Final)
Ajuste na rotina PEDVEI011.prw para puxar a informação do Tipo do Pedido do SIGAVEI para o SIGAFAT... assim será considerado na exceção Fiscal cadastrada.
