### PR TITLE
GAP248 | Melhoria na Onda para Itens Similar e quantidade de Itens Substituto

### DIFF
--- a/SIGAPEC/Classes/SaldoCAOAPEC.PRW
+++ b/SIGAPEC/Classes/SaldoCAOAPEC.PRW
@@ -72,8 +72,8 @@ Method CarregaCAOAPEC(cCodProd, cArmazem, cGrupo, cMarca, nSaldoSB2) class Saldo
 	DeFault nSaldoSB2	:= 0
 
 	Begin Sequence
-		::_cCodProd 	:= cCodProd
-		::_cArmazem		:= cArmazem 
+		::_cCodProd 	:= PADR(ALLTRIM(cCodProd),TAMSX3("B1_COD"  )[1]) // cCodProd
+		::_cArmazem		:= PADR(ALLTRIM(cArmazem),TAMSX3("B2_LOCAL")[1]) //cArmazem 
 		::_cGrupo   	:= cGrupo
 		::_cMarca 		:= cMarca
 		::_nSaldoEST	:= nSaldoSB2  	//Saldo Protheus
@@ -101,8 +101,8 @@ Method RetSldCAOAPEC() class SaldoCAOAPEC
 	Local _cAliasPesq	:= GetNextAlias()   
 	Local cWhere 		:= ""
 	Local aSaldo		:= {}
-	Local cCodProd 		:= AllTrim(::_cCodProd)
-	Local cArmazem 		:= ""
+	Local cCodProd 		:= ::_cCodProd
+	Local cArmazem 		:= ::_cArmazem
 	Local nSaldoSB2     := 0
 	Local oZPEC08Peca
 	Local nPos
@@ -203,8 +203,12 @@ Method RetSldCAOAPEC() class SaldoCAOAPEC
 		//Garantir que carrega saldo WIS
 		::_nSaldoWIS := Self:RetSaldoWIS()  //carrego o valor do saldo WIS
 
-		If ::_nSaldoWIS == 0 .Or. ::_nSaldoEST == 0 
-			Aadd(::_aError, "Produto "+AllTrim(cCodProd)+", com saldo Protheus "+AllTrim(Str(::_nSaldoEST))+" Saldo atual Wis "+AllTrim(Str(::_nSaldoWis))+" Armazem "+cArmazem+", possui saldo zerado em uma das opções, SALDO INVALIDO ! ")
+		If ::_nSaldoWIS == 0 
+			Aadd(::_aError, "Produto "+AllTrim(cCodProd)+", Saldo atual Protheus "+AllTrim(Str(::_nSaldoEST))+" Saldo atual Wis "+AllTrim(Str(::_nSaldoWis))+" Armazem "+cArmazem+", possui saldo zerado no WIS, SALDO INVALIDO ! ")
+			Break
+		Endif
+		If ::_nSaldoEST == 0 
+			Aadd(::_aError, "Produto "+AllTrim(cCodProd)+", Saldo atual Protheus "+AllTrim(Str(::_nSaldoEST))+" Saldo atual Wis "+AllTrim(Str(::_nSaldoWis))+" Armazem "+cArmazem+", possui saldo zerado no Protheus, SALDO INVALIDO ! ")
 			Break
 		Endif
 		If ::_nSaldoWIS < nSaldoSB2 
@@ -296,6 +300,7 @@ Method RetSaldoWIS() class SaldoCAOAPEC
 		Else
 			nSaldoWIS := 0
 		EndIf
+		//nSaldoWIS := 1000 // para Simular saldo no WIS
 		//apaga arquivo temporario criado
 		If Select((cAlsWis)) <> 0
 			(cAlsWis)->(DbCloseArea())

--- a/SIGAPEC/Funcao/ZPECF008.PRW
+++ b/SIGAPEC/Funcao/ZPECF008.PRW
@@ -1105,14 +1105,14 @@ Local _nCount
 		oZPEC08Peca:SetGrupo(_cGrupo)
 		oZPEC08Peca:SetCodigo(_cCodItem)
 		_aItemRelac := oZPEC08Peca:ItensSubstituidos()
-
+		aSort(_aItemRelac,,,{|x,y| x[4] > y[4]})
 		If Len(_aItemRelac) == 0 .or. Empty(AllTrim(_aItemRelac[1,2]))
 			Aadd(_aMensAglu,"Não existe item Substitutos para o produto " +AllTrim(_cCodItem))	
 			Break	
 		Endif
 		For _nPos := 1 To Len(_aItemRelac)
 			_cGrupoSubst	:= _aItemRelac[_nPos,1]
-			_cCodSubst 		:= AllTrim(_aItemRelac[_nPos,2])
+			_cCodSubst 		:= _aItemRelac[_nPos,2]//AllTrim(_aItemRelac[_nPos,2])
 			_nSaldoSB2 		:= _aItemRelac[_nPos,7]
 			
 			//GAP098 | Desmembrar itens bloqueados por inventário - Alteração funcionalidade de verificação saldo WIS e Protheus DAC 08/11/2023
@@ -1192,14 +1192,14 @@ Static Function ZPECF08SIM( _cNumOrc, _cGrupo, _cCodItem, _cLocal, _nQtdeItem, _
 		oZPEC08Peca:SetCodigo(_cCodItem)
 		_aItemSim := oZPEC08Peca:ItensRelacionados()
 		//aAuxAtu := oZPEC08Peca:EstqSaldo(,.t.,.t.)
-
-		If Len(_aItemSim) == 0 .or. Empty(AllTrim(_aItemSim[1,2]))
+		aSort(_aItemSim,,,{|x,y| x[4] > y[4]})
+ 		If Len(_aItemSim) == 0 .or. Empty(AllTrim(_aItemSim[1,2]))
 			Aadd(_aMensAglu,"Não existe item Similar para o produto " +AllTrim(_cCodItem))	
 			Break	
 		Endif
 		For _nPos := 1 To Len(_aItemSim)
 			_cGrupoSubst	:= _aItemSim[_nPos,1]
-			_cCodSimilar	:= AllTrim(_aItemSim[_nPos,2])
+			_cCodSimilar	:= _aItemSim[_nPos,2]//AllTrim(_aItemSim[_nPos,2])
 			_nSaldoSB2 		:= _aItemSim[_nPos,4] //SB2->(SaldoSB2())
 
 			//GAP098 | Desmembrar itens bloqueados por inventário - Alteração funcionalidade de verificação saldo WIS e Protheus DAC 08/11/2023
@@ -1210,7 +1210,8 @@ Static Function ZPECF08SIM( _cNumOrc, _cGrupo, _cCodItem, _cLocal, _nQtdeItem, _
 				For _nCount := 1 To Len(_oSaldoPec:_aError)
 					Aadd(_aMensAglu, _oSaldoPec:_aError[_nCount])
 				Next _nCount
-				Break 
+				Break
+				//Loop 
 			Endif	
 			_nSaldoSB2 := _oSaldoPec:_nSaldoPEC
 			//Caso esteja zerado
@@ -1232,7 +1233,7 @@ Static Function ZPECF08SIM( _cNumOrc, _cGrupo, _cCodItem, _cLocal, _nQtdeItem, _
 			//Se zerou é por que conseguiu atingir todos os produtos
 			//VERIFICAR POSTERIORMENTE SE IRA PODER SER COM PARCIAL CASO SEJA AI TEM QUE RETORNAR VERDADEIRO E MONTAR OUTRO ORÇAMENTO COM A QUANTIDADE FALTANTE
 			If Len(_oSaldoPec:_aMsg) > 0  //ocorreu problemas no calculo
-				Aadd(_aMensAglu,"Utiizado saldo do item Similar " +AllTrim(_cCodSimilar)+ " para o produto " +AllTrim(_cCodItem))	
+				Aadd(_aMensAglu,"Utilizado saldo do item Similar " +AllTrim(_cCodSimilar)+ " para o produto " +AllTrim(_cCodItem))	
 				For _nCount := 1 To Len(_oSaldoPec:_aMsg)
 					Aadd(_aMensAglu, _oSaldoPec:_aMsg[_nCount])
 				Next _nCount
@@ -1852,7 +1853,7 @@ Static Function ZPECF08PARC( _cNumOrc, _cGrupo, _cCodItem, _cLocal, _cCodSubst, 
 			Aadd(_aMensAglu,"Não foi possivel alterar registro na tabela VS3 (ZPECF08PARC) !")
 			Break
 		EndIf	
-		If _nQtdReal <= 0 .and. _nItenNovo == VS3->VS3_QTDINI
+		If _nQtdReal <= 0 .and. (_nItenNovo == VS3->VS3_QTDINI .or._nItenNovo == 0)
 			VS3->(DbDelete())
 			VS3->(MsUnlock())
 			Break

--- a/SIGAPEC/Funcao/ZPECFUNA.PRW
+++ b/SIGAPEC/Funcao/ZPECFUNA.PRW
@@ -846,7 +846,7 @@ User Function XCLONEOR( _aOrc, _aCpoVazio, _lXBO, _lApagaIT, _aObs)
 			VS3->(DbGoto(_aRegVS3Del[_nPos]))
 			VS3->(RecLock("VS3",.F.))
 			_cObs 	:= "REFERENTE AO PROCESSO AGLUTINAÇÃO NR. "+_cAglutina + CRLF
-			_cObs	+= "REGISTRO EXCLUÍDO NO PROCESSO DE CLONAGEM DO ITEM "+AllTrim(VS3->VS3_CODITE)+" EM "+DtoC(Date())+" "+Time()	
+			_cObs	+= "REGISTRO EXCLUÝDO NO PROCESSO DE CLONAGEM DO ITEM "+AllTrim(VS3->VS3_CODITE)+" EM "+DtoC(Date())+" "+Time()	
 			VS3->VS3_OBSAGL	:= Upper(_cObs) +CRLF+ VS3->VS3_OBSAGL
 			//Não zerar causara erros somente apagar
 			VS3->(DbDelete())
@@ -3264,6 +3264,7 @@ User Function XMOVA261(_cNumOrc, _cCodProd, _cArmorig, _cArmdes, _nQtde, _nRegvs
 	Local _aMsgErro		:= {}
 	Local _cErro
 	Local _nPos
+	Local _nSaldo       :=0
 
 	Default _cCodProd	:= ""
 	Default _cNumOrc	:= ""
@@ -3343,7 +3344,29 @@ User Function XMOVA261(_cNumOrc, _cCodProd, _cArmorig, _cArmdes, _nQtde, _nRegvs
 			MSGINFO( _cErro, "[ZPECF013_MANUTENCAO] - Atenção" )
 			_lRet := .F.
 			Break
-		Endif	
+		Endif
+		
+		DbSelectArea('SB2')
+		SB2->(DbSetOrder(1))
+		if SB2->(dBseek(xFilial("SB2") + SB1->B1_COD + _cArmorig))
+			
+			_nSaldo := SaldoSB2()
+			
+			if _nSaldo <= 0
+				_cErro := "Produto " + _cCodProd+ "  n�o Possue saldo no Armazem " + _cArmorig+ "  !!! " 
+				AAdd(_aMsgErro,_cErro)
+				MSGINFO( _cErro, "[ZPECF013_MANUTENCAO] - Atenção" )
+				_lRet := .F.
+				Break
+			endif
+		
+		Else
+			_cErro := "Produto " + _cCodProd+ "  n�o encontrado no Armazem " + _cArmorig+ "  !!! " 
+			AAdd(_aMsgErro,_cErro)
+			MSGINFO( _cErro, "[ZPECF013_MANUTENCAO] - Atenção" )
+			_lRet := .F.
+			Break
+		EndIf
 		_aLinha 	:= {}
 		//origem
 		//aadd(aLinha,{"D3_FILIAL" ,  	xFilial("SD3")			, Nil})
@@ -4382,6 +4405,28 @@ Static Function XRESCAOATR(_cNumOrc, _lReserva, _aRegVS3, _cArmorig, _cArmdes, _
 				Break
 			ElseIf _cOrigem == _cDestino
 				AAdd(_aMsg,"Verificar armazem origem "+_cOrigem+" e ou destino "+_cDestino+" para orçamento " +_cNumOrc+ " os mesmos estão iguais, não será realizada processo de Reserva comunicar ADM Sistemas!!! ")
+				_lRet := .F.
+				Break
+			EndIf
+			DbSelectArea('SB2')
+			SB2->(DbSetOrder(1))
+			if SB2->(dBseek(xFilial("SB2") + _cCodProd + _cOrigem))
+			
+				_nSaldo := SaldoSB2()
+				
+				if _nSaldo <= 0
+					_cErro := "Produto " + _cCodProd + "  n�o Possue saldo no Armazem " + _cOrigem + "  !!! " 
+					AAdd(_aMsgErro,_cErro)
+					//MSGINFO( _cErro, "[ZPECF013_MANUTENCAO] - Atenção" )
+					_lRet := .F.
+					(_cAliasPesq)->(DbSkip())
+					Loop
+				endif
+			
+			Else
+				_cErro := "Produto " + _cCodProd + "  n�o encontrado no Armazem " + _cOrigem + "  !!! " 
+				AAdd(_aMsgErro,_cErro)
+				//MSGINFO( _cErro, "[ZPECF013_MANUTENCAO] - Atenção" )
 				_lRet := .F.
 				Break
 			EndIf


### PR DESCRIPTION
INC0117653 | A onda de picking não está considerando todas as possibilidades de similaridade.
 Ajustado para selecionar o produto similar que contiver maior saldo disponível

INC0118040 | Quando item é substituído, está ocorrendo a tentativa de movimentação dele e a soma da qde no substituto.
Quando Ocorrer a substituição total do item, o mesmo será excluído do orçamento, para não interferir na soma dos itens. 