### PR TITLE
GAP250 | Inclusão das TAGS No XML FCI, Pedido, Item Pedido

### DIFF
--- a/Ponto de Entrada/PEDVEI011_PE.prw
+++ b/Ponto de Entrada/PEDVEI011_PE.prw
@@ -12,29 +12,31 @@
 */
 
 User Function PEDVEI011()
-  
+
 	Local nPosTES
  
 	//alert("PEDVEI011")
 	Conout("PEDVEI011")
 	Conout("PEDVEI011 - C6_XBASST " + cValToChar(VVA->VVA_XBASST))
-	
+	 
 	aAdd(aCabPV,  {"C5_XMENSER" ,E_MSMM(VV0->VV0_OBSMNF)   ,Nil}) 
 	aAdd(aCabPV,  {"C5_CLIREM"  , VV0->VV0_CLIRET 		   ,Nil}) 
 	aAdd(aCabPV,  {"C5_LOJAREM" , VV0->VV0_LOJRET 		   ,Nil}) 
-	aAdd(aCabPV,  {"C5_TIPOCLI" , VRJ->VRJ_TIPOCL 		   ,Nil}) // Adicionado Por Cintia Araujo - 08/2024 para trazer informação do Pedido Montadora e considerar a Exceçao Fiscal conforme Tipo de Pedido
-
 	AADD(aIteTPv, {"C6_NUMSERI" , VVA->VVA_CHASSI          ,NIL})
 	AADD(aIteTPv, {"C6_XBASST"  , VVA->VVA_XBASST          ,NIL})
-	AADD(aIteTPv, {"C6_QTDLIB"  , 1                        ,NIL}) // Para correca de Erro do Padrao Protheus
+	AADD(aIteTPv, {"C6_QTDLIB"  , 1                        ,NIL}) // Para correÃ§Ã£o de Erro do PadrÃ£o Protheus
 	AADD(aIteTPv, {"C6_XBASPI"  , VVA->VVA_XBASPI          ,NIL})
 	AADD(aIteTPv, {"C6_XBASCO"  , VVA->VVA_XBASCO          ,NIL})
 	AADD(aIteTPv, {"C6_XBASIP"  , VVA->VVA_XBASIP          ,NIL})
+	
+	If VRJ->(FieldPos("VRJ_PEDCOM")) > 0 .And. VRJ->(FieldPos("VRJ_XITEMP")) > 0 
+		AADD(aIteTPv, {"C6_NUMPCOM" , VRJ->VRJ_PEDCOM      ,NIL})
+		AADD(aIteTPv, {"C6_ITEMPC"  , VRJ->VRJ_XITEMPC     ,NIL})
+	EndIf
+
 	If ! Empty(VVA->VVA_VRKNUM)
 		VRK->(dbSetOrder(1))
 		If VRK->(dbSeek(xFilial("VRK") + Left(VVA->VVA_VRKNUM, TamSX3("VRK_PEDIDO")[1]) + VVA->VVA_VRKITE))
-
-
 			AADD(aIteTPv, {"C6_XPECOM"  , VRK->VRK_XPECOM ,NIL})
 			AADD(aIteTPv, {"C6_XVLCOM"  , VRK->VRK_XVLCOM ,NIL})
 

--- a/SIGAFAT/Função/nfesefaz.prw
+++ b/SIGAFAT/Função/nfesefaz.prw
@@ -2680,15 +2680,9 @@ If cTipo == "1"
 						Else
 							cMunPres := ConvType(aUF[aScan(aUF,{|x| x[1] == aDest[09]})][02]+aDest[07])
 						EndIf
-
-						//************ Especifico Caoa ******************
-						//Ajuste realizado para atender a venda dos HR para a HMB
-						If AllTrim(SC6->C6_TES) == '802' .And. AllTrim(SC6->C6_CLI) == '000008' .And. AllTrim(SC6->C6_LOJA) == '05'
-							aadd(aPedCom,{"5500012312","10"})
-							//*******************************************
-
+ 
 						// Tags xPed e nItemPed (controle de B2B) para nota de saída
-						ElseIf SC6->(FieldPos("C6_NUMPCOM")) > 0 .And. SC6->(FieldPos("C6_ITEMPC")) > 0
+						If SC6->(FieldPos("C6_NUMPCOM")) > 0 .And. SC6->(FieldPos("C6_ITEMPC")) > 0
 							If !Empty(SC6->C6_NUMPCOM) .And. !Empty(SC6->C6_ITEMPC) 
 								aadd(aPedCom,{SC6->C6_NUMPCOM,SC6->C6_ITEMPC})
 							Else
@@ -2698,6 +2692,26 @@ If cTipo == "1"
 							aadd(aPedCom,{})
 						EndIf
 						
+						//************ Especifico Caoa ******************
+						//Ajuste realizado para atender a venda dos HR para a HMB
+						If Len(aPedCom) <= 0
+							If AllTrim(SC6->C6_TES) == '802' .And. AllTrim(SC6->C6_CLI) == '000008' .And. AllTrim(SC6->C6_LOJA) == '05'
+								If !Empty(SC6->C6_NUMPCOM) .And. !Empty(SC6->C6_ITEMPC) 
+									aadd(aPedCom,{SC6->C6_NUMPCOM,SC6->C6_ITEMPC})
+								Else
+									aadd(aPedCom,{"5500012312","10"})
+								EndIf 
+
+							Elseif AllTrim(SC6->C6_TES) == '801' .And. AllTrim(SC6->C6_CLI) == '000008' .And. AllTrim(SC6->C6_LOJA) == '05'
+								If !Empty(SC6->C6_NUMPCOM) .And. !Empty(SC6->C6_ITEMPC) 
+									aadd(aPedCom,{SC6->C6_NUMPCOM,SC6->C6_ITEMPC})
+								Else
+									aadd(aPedCom,{"5500012312","20"})
+								EndIf
+ 							EndIf
+						EndIf
+
+						//************ 
 						//Conforme Decreto RICM, N 43.080/2002 valido somente em MG deduzir o
 						//imposto dispensado na operação
 						nDescRed := 0
@@ -2804,7 +2818,7 @@ If cTipo == "1"
 		
 						cCodProd  := (cAliasSD2)->D2_COD	            
 						cDescProd := IIF(Empty(SC6->C6_DESCRI),SB1->B1_DESC,SC6->C6_DESCRI) 
-						 
+						  
 						If !Empty((cAliasSD2)->D2_IDENTB6) .And. lNFPTER  
 				         	If SC5->C5_TIPO == "N" 
 						         //--A7_FILIAL + A7_CLIENTE + A7_LOJA + A7_PRODUTO
@@ -2821,7 +2835,7 @@ If cTipo == "1"
 						            cDescProd := SA5->A5_DESREF 	            
 						         EndIf 	
 					      	EndIf  
-			         	EndIf 
+			         	EndIf  
 			         
 			            nDescZF := (cAliasSD2)->D2_DESCZFR 
 			            
@@ -2879,7 +2893,7 @@ If cTipo == "1"
 							If (cAliasSD2)->(FieldPos("D2_FCICOD")) > 0 .And. !Empty((cAliasSD2)->D2_FCICOD)
 								aadd(aFCI,{(cAliasSD2)->D2_FCICOD}) 
 								
-								If lFCI
+								If lFCI 
 									cMsgFci	:= "Resolucao do Senado Federal núm. 13/12"
 									cInfAdic  += cMsgFci + ", Numero da FCI " + Alltrim((cAliasSD2)->D2_FCICOD) + "."
 								EndIf
@@ -2890,6 +2904,13 @@ If cTipo == "1"
 						Else 
 							aadd(aFCI,{})
 						EndIf
+
+						//************ Especifico Caoa ******************
+						//Ajuste realizado para atender a venda dos HR para a HMB			
+						If Len(aFCI) <= 0 .And. AllTrim(SD2->D2_TES) == '801' .And. AllTrim(SD2->D2_CLIENTE) == '000008' .And. AllTrim(SD2->D2_LOJA) == '05'
+							aadd(aFCI,{"D4746E77-0A66-4782-B107-864BBEBE3A68"}) 
+						EndIf
+
 						// Retirada a validação devido a criação da tag nFCI (NT 2013/006)
 						//--------------------------------------------------------------------------------
 						//Campo SD2->D2_FCICOD só é preenchido nos casos de Industrialização Interestadual
@@ -9141,7 +9162,7 @@ If Len(aCOFINS)>0
 	cString += '<vlTrib>'+ConvType(aCOFINS[06],15,4)+'</vlTrib>'
 	cString += '<qTrib>'+ConvType(aCOFINS[05],16,4)+'</qTrib>'
 	cString += '<valor>'+ConvType(aCOFINS[04],15,2)+'</valor>'
-	//cString += If(retNT2005(), '<indSomaCOFINSST>'+ Iif(aCOFINSST[07] == "1", ConvType(aCOFINSST[07],1), "0") +'</indSomaCOFINSST>', '')  //*************** Especifico Caoa ********************
+	//cString += If(retNT2005(), '<indSomaCOFINSST>'+ Iif(aCOFINSST[07] == "1", ConvType(aCOFINSST[07],1), "0") +'</indSomaCOFINSST>', '')  //************ Especifico Caoa ******************
 	cString += '</Tributo>'
 	nValCof += aCOFINS[04]
 Else


### PR DESCRIPTION
Inclusão das TAGS No XML FCI, Pedido, Item Pedido

Como solução Paliativa emergencial, alteração no fonte NFESefaz.prw para adicionar as regras :

1.           Quando campo C6_NUMPCOM e C6_ITEMPC não estiverem preenchidos e o cliente for 000008/05 e TES 801 forçar o preenchimento da TAG xPed = 5500012312 e nItemPed = 20
2.           Quando campo C6_NUMPCOM e C6_ITEMPC não estiverem preenchidos e o cliente for 000008/05 e TES 802 forçar o preenchimento da TAG xPed = 5500012312 e nItemPed = 10
3.           Quando campo D2_FCICOD não estiver preenchido e o cliente for 000008/05 e TES 801 forçar o preenchimento da TAG  nFCI = D4746E77-0A66-4782-B107-864BBEBE3A68"


Como solução definitiva:

1.          Criar o campo VRJ_XITEMPC, que será preenchido no cabeçalho do 'Pedido Montadora', campo criado no cabeçalho pois conforme levantado por Micaellen, não haverá  pedido/item de compras diferentes para um unico Pedido Montadora.

2.          Alterar o fonte PEDVEI011_PE.prw para trazer a informação dos campos :
                    VRJ_PEDCOM  para  C6_NUMPCOM 
                    VRJ_XITEMPC  para  C6_ITEMPC
 
3.          Instrução para Micaellen abrir Ticket solicitando configuração e treinamento para preenchimento do campo D2_FCICOD, que será utilizado para gerar a TAG nFCI  no XML, de forma padrão.

[sx3_vrj.zip](https://github.com/user-attachments/files/16753049/sx3_vrj.zip)

