### PR TITLE
GAP250.1 | Inclusão das TAGS No XML FCI, Pedido, Item Pedido

### DIFF
--- a/SIGAFAT/Função/nfesefaz.prw
+++ b/SIGAFAT/Função/nfesefaz.prw
@@ -2688,8 +2688,6 @@ If cTipo == "1"
 							Else
 								aadd(aPedCom,{})
 							EndIf
-						Else
-							aadd(aPedCom,{})
 						EndIf
 						
 						//************ Especifico Caoa ******************
@@ -2699,16 +2697,15 @@ If cTipo == "1"
 								If !Empty(SC6->C6_NUMPCOM) .And. !Empty(SC6->C6_ITEMPC) 
 									aadd(aPedCom,{SC6->C6_NUMPCOM,SC6->C6_ITEMPC})
 								Else
-									aadd(aPedCom,{"5500012312","10"})
+									aadd(aPedCom,{"5500012312","000020"})
 								EndIf 
-
-							Elseif AllTrim(SC6->C6_TES) == '801' .And. AllTrim(SC6->C6_CLI) == '000008' .And. AllTrim(SC6->C6_LOJA) == '05'
-								If !Empty(SC6->C6_NUMPCOM) .And. !Empty(SC6->C6_ITEMPC) 
-									aadd(aPedCom,{SC6->C6_NUMPCOM,SC6->C6_ITEMPC})
-								Else
-									aadd(aPedCom,{"5500012312","20"})
-								EndIf
+							//Else
+							//	aadd(aPedCom,{})
  							EndIf
+						EndIf
+
+						If Len(aPedCom) <= 0
+							aadd(aPedCom,{})
 						EndIf
 
 						//************ 
@@ -2893,22 +2890,24 @@ If cTipo == "1"
 							If (cAliasSD2)->(FieldPos("D2_FCICOD")) > 0 .And. !Empty((cAliasSD2)->D2_FCICOD)
 								aadd(aFCI,{(cAliasSD2)->D2_FCICOD}) 
 								
-								If lFCI 
+								If lFCI  
 									cMsgFci	:= "Resolucao do Senado Federal núm. 13/12"
 									cInfAdic  += cMsgFci + ", Numero da FCI " + Alltrim((cAliasSD2)->D2_FCICOD) + "."
 								EndIf
 								
-							Else
-								aadd(aFCI,{})
+							//Else
+							//	aadd(aFCI,{})
 							EndIf
-						Else 
-							aadd(aFCI,{})
 						EndIf
 
 						//************ Especifico Caoa ******************
 						//Ajuste realizado para atender a venda dos HR para a HMB			
-						If Len(aFCI) <= 0 .And. AllTrim(SD2->D2_TES) == '801' .And. AllTrim(SD2->D2_CLIENTE) == '000008' .And. AllTrim(SD2->D2_LOJA) == '05'
+						If Len(aFCI) <= 0 .And. AllTrim(SD2->D2_TES) == '802' .And. AllTrim(SD2->D2_CLIENTE) == '000008' .And. AllTrim(SD2->D2_LOJA) == '05'
 							aadd(aFCI,{"D4746E77-0A66-4782-B107-864BBEBE3A68"}) 
+						EndIf
+
+						If Len(aFCI) <= 0
+							aadd(aFCI,{})
 						EndIf
 
 						// Retirada a validação devido a criação da tag nFCI (NT 2013/006)


### PR DESCRIPTION
Solução:
Inclusão das TAGS No XML FCI, Pedido, Item Pedido

Como solução Paliativa emergencial, alteração no fonte NFESefaz.prw para adicionar as regras :

1.           Quando campo C6_NUMPCOM e C6_ITEMPC não estiverem preenchidos e o cliente for 000008/05 e TES 801 forçar o preenchimento da TAG xPed = 5500012312 e nItemPed = 20
2.           Quando campo C6_NUMPCOM e C6_ITEMPC não estiverem preenchidos e o cliente for 000008/05 e TES 802 forçar o preenchimento da TAG xPed = 5500012312 e nItemPed = 10
3.           Quando campo D2_FCICOD não estiver preenchido e o cliente for 000008/05 e TES 801 forçar o preenchimento da TAG  nFCI = D4746E77-0A66-4782-B107-864BBEBE3A68"


Como solução definitiva:

1.          Criar o campo VRJ_XITEMPC, que será preenchido no cabeçalho do 'Pedido Montadora', campo criado no cabeçalho pois conforme levantado por Micaellen, não haverá  pedido/item de compras diferentes para um unico Pedido Montadora.

2.          Alterar o fonte PEDVEI011_PE.prw para trazer a informação dos campos :
                    VRJ_PEDCOM  para  C6_NUMPCOM 
                    VRJ_XITEMPC  para  C6_ITEMPC
 
3.          Instrução para Micaellen abrir Ticket solicitando configuração e treinamento para preenchimento do campo D2_FCICOD, que será utilizado para gerar a TAG nFCI  no XML, de forma padrão.

[sx3_vrj.zip](https://github.com/user-attachments/files/16753049/sx3_vrj.zip)
