### PR TITLE
GAP250.2 | Inclusão das TAGS No XML FCI, Pedido, Item Pedido

### DIFF
--- a/SIGAFAT/Função/nfesefaz.prw
+++ b/SIGAFAT/Função/nfesefaz.prw
@@ -2685,24 +2685,16 @@ If cTipo == "1"
 						If SC6->(FieldPos("C6_NUMPCOM")) > 0 .And. SC6->(FieldPos("C6_ITEMPC")) > 0
 							If !Empty(SC6->C6_NUMPCOM) .And. !Empty(SC6->C6_ITEMPC) 
 								aadd(aPedCom,{SC6->C6_NUMPCOM,SC6->C6_ITEMPC})
-							Else
-								aadd(aPedCom,{})
+							//Else 
+							//	aadd(aPedCom,{})
 							EndIf
 						EndIf
 						
 						//************ Especifico Caoa ******************
 						//Ajuste realizado para atender a venda dos HR para a HMB
-						If Len(aPedCom) <= 0
-							If AllTrim(SC6->C6_TES) == '802' .And. AllTrim(SC6->C6_CLI) == '000008' .And. AllTrim(SC6->C6_LOJA) == '05'
-								If !Empty(SC6->C6_NUMPCOM) .And. !Empty(SC6->C6_ITEMPC) 
-									aadd(aPedCom,{SC6->C6_NUMPCOM,SC6->C6_ITEMPC})
-								Else
-									aadd(aPedCom,{"5500012312","000020"})
-								EndIf 
-							//Else
-							//	aadd(aPedCom,{})
- 							EndIf
-						EndIf
+						If Len(aPedCom) <= 0 .And. AllTrim(SC6->C6_TES) == '802' .And. AllTrim(SC6->C6_CLI) == '000008' .And. AllTrim(SC6->C6_LOJA) == '05'
+							aadd(aPedCom,{"5500012312","000020"})
+						EndIf 
 
 						If Len(aPedCom) <= 0
 							aadd(aPedCom,{})


### PR DESCRIPTION
Inclusão das TAGS No XML FCI, Pedido, Item Pedido

Como solução Paliativa emergencial, alteração no fonte NFESefaz.prw para adicionar as regras :

      Quando campo C6_NUMPCOM e C6_ITEMPC não estiverem preenchidos e o cliente for 000008/05 e TES 801 forçar o preenchimento da TAG xPed = 5500012312 e nItemPed = 20
      Quando campo C6_NUMPCOM e C6_ITEMPC não estiverem preenchidos e o cliente for 000008/05 e TES 802 forçar o preenchimento da TAG xPed = 5500012312 e nItemPed = 10
      Quando campo D2_FCICOD não estiver preenchido e o cliente for 000008/05 e TES 801 forçar o preenchimento da TAG  nFCI = D4746E77-0A66-4782-B107-864BBEBE3A68"
Como solução definitiva:

     Criar o campo VRJ_XITEMPC, que será preenchido no cabeçalho do 'Pedido Montadora', campo criado no cabeçalho pois conforme levantado por Micaellen, não haverá  pedido/item de compras diferentes para um unico Pedido Montadora.
     Alterar o fonte PEDVEI011_PE.prw para trazer a informação dos campos :
             VRJ_PEDCOM  para  C6_NUMPCOM 
             VRJ_XITEMPC  para  C6_ITEMPC
     Instrução para Micaellen abrir Ticket solicitando configuração e treinamento para preenchimento do campo D2_FCICOD, que será utilizado para gerar a TAG nFCI  no XML, de forma padrão.
[sx3_vrj.zip](https://github.com/user-attachments/files/16753049/sx3_vrj.zip)