### PR TITLE
GAP253 | contabilizada, só que a nota fiscal não foi integrada ao SAP e também não aparece na tabela SZ7.

### DIFF
--- a/Integracoes/SAP/ZGENSAP.prw
+++ b/Integracoes/SAP/ZGENSAP.prw
@@ -807,6 +807,15 @@ User Function ZF11GENSAP(cxFil,cTab,cIndice,cChave,nOperPro,nOperSAP,cXMLSZ7,cSt
             SZ7->Z7_RECORI := SE2->(Recno())
             SZ7->Z7_CLIFOR := SE2->E2_FORNECE
             SZ7->Z7_LOJA := SE2->E2_LOJA
+        Elseif cTab == "CT2" .and. Alltrim(SZ7->Z7_ORIGEM) == "MATA997"
+            SZ7->Z7_DOCORI := SF2->F2_DOC
+            SZ7->Z7_SERORI := SF2->F2_SERIE
+            If (Len(aDadosOri) > 3 .and. Empty(aDadosOri[4])) .or. Empty(aDadosOri)
+                SZ7->Z7_RECORI := SF2->(Recno())
+            Endif
+            SZ7->Z7_TIPONF := SF2->F2_TIPO
+            SZ7->Z7_CLIFOR := SF2->F2_CLIENTE
+            SZ7->Z7_LOJA := SF2->F2_LOJA
         // contabilizacao de movimentos de estoque, excluindo nota de entrada e saida
 //        Elseif cTab == "CT2" .and. "MATA" $ Alltrim(SZ7->Z7_ORIGEM) .and. SD3->(!Eof()) .and. SD3->(!Bof()) ;
 //        .and. !"MATA103/GFEA065/MATA140/MATA460/MATA460A/MATA460B/MATA116" $ Alltrim(SZ7->Z7_ORIGEM)


### PR DESCRIPTION

Atualização da consulta para selecionar os movimentos contábil da origem MATA997.
Adicionar ao Parâmetro CAOASAP09A o conteúdo ’|MATA997' ao que já existe