### PR TITLE
GAP256 | Alterar Pedido + Item do para 5500012312 + 000040

### DIFF
--- a/SIGAFAT/Função/nfesefaz.prw
+++ b/SIGAFAT/Função/nfesefaz.prw
@@ -2684,7 +2684,11 @@ If cTipo == "1"
 						//************ Especifico Caoa ******************
 						//Ajuste realizado para atender a venda dos HR para a HMB
 						If AllTrim(SC6->C6_TES) == '802' .And. AllTrim(SC6->C6_CLI) == '000008' .And. AllTrim(SC6->C6_LOJA) == '05'
-							aadd(aPedCom,{"5500012312","000020"})
+							If !Empty(SC6->C6_NUMPCOM) .And. !Empty(SC6->C6_ITEMPC) 
+								aadd(aPedCom,{SC6->C6_NUMPCOM,SC6->C6_ITEMPC})
+							Else
+								aadd(aPedCom,{"5500012312","000020"})
+							EndIf
 							//*******************************************
 
 						// Tags xPed e nItemPed (controle de B2B) para nota de saída


### PR DESCRIPTION
Criado o campo VRJ_XITEMPC e compilado o fonte PEDVEI011_PE.prw, conforme solicitados o Ticket INC0119963, para trazer a informação dos campos:
VRJ_PEDCOM para C6_NUMPCOM
VRJ_XITEMPC para C6_ITEMPC

Assim, realizada a alteração no fonte NFESefaz.prw para adicionar as regras :
         1 - Quando campos C6_NUMPCOM e C6_ITEMPC não estiverem preenchidos e o cliente for 000008/05 e TES 802 forçar o preenchimento da TAG xPed = 5500012312 e nItemPed = 000040
         2 - Quando campos C6_NUMPCOM e C6_ITEMPC estiverem preenchidos, os dados serão levados para o XML
