### PR TITLE
GAP258 | Inclusão de Semáforo no Processo da Onda #632

### DIFF
--- a/Integracoes/RgLog - SILT/ZWSR012.prw
+++ b/Integracoes/RgLog - SILT/ZWSR012.prw
@@ -52,6 +52,7 @@ Local _cHsIni		:= Time()
 Local _aDivergencia	:= {}
 Local _nRetJson		:= 0
 Local _cChave		:= "ZPECF008_ONDA"
+Local _lSemaforo	:= SuperGetMV( "CMV_PEC052" ,, .F. )
 Local _nPos
 Local _lRet
 
@@ -166,6 +167,8 @@ Private _aJson		:= {}
 	EndIf
 
 	//Caso esteja rodando onda não será permitido fazer a transferencia
+	_cChave += AllTrim(cEmpAnt)+AllTrim(cFilAnt)
+	_lSemaforo := .F. 	//Caso não utilize o semaforo para RGLOG desabilitar
 	If !LockByName(_cChave,.T.,.T.)  
 		//tentar locar por 10 segundos caso não consiga não prosseguir
 		_lRet := .F.
@@ -185,8 +188,10 @@ Private _aJson		:= {}
 			Return(.T.)
 		EndIf
 	EndIf
-	//Liberar a chave	
-	UnLockByName(_cChave,.T.,.T.)
+	//Caso não utilize o semaforo para RGLOG desabilitar
+	If !_lSemaforo
+		UnLockByName(_cChave,.T.,.T.)
+	Endif 
 
 	_cNfFor 	:= AllTrim(StrZero(Val(oParseJSON:nota_fiscal),9))
 	_cSerFor 	:= AllTrim(oParseJSON:serie_nf)
@@ -210,6 +215,10 @@ Private _aJson		:= {}
 		oJsonRet['errorCode'] 		:= 400
 		oJsonRet['errorMessage']	:= AllTrim(_cErro)
 		::SetResponse( oJsonRet:ToJson() )
+		//Liberar a chave	
+		If _lSemaforo
+			UnLockByName(_cChave,.T.,.T.)
+		Endif 
 		Return(.T.)
  	EndIf
 
@@ -220,6 +229,10 @@ Private _aJson		:= {}
 		oJsonRet['errorCode'] 		:= 400
 		oJsonRet['errorMessage']	:= AllTrim(_cErro)
 		::SetResponse( oJsonRet:ToJson() )
+		//Liberar a chave	
+		If _lSemaforo
+			UnLockByName(_cChave,.T.,.T.)
+		Endif 
 		Return(.T.)
  	EndIf
 
@@ -233,6 +246,10 @@ Private _aJson		:= {}
 		oJsonRet['errorCode'] 		:= 400
 		oJsonRet['errorMessage']	:= AllTrim(_cErro)
 		::SetResponse( oJsonRet:ToJson() )
+		//Liberar a chave	
+		If _lSemaforo
+			UnLockByName(_cChave,.T.,.T.)
+		Endif 
 		Return(.T.)
 	Endif
 	//Para Transferência
@@ -276,7 +293,11 @@ Private _aJson		:= {}
 	//Caso tenha divergencia ESPFUN.-.PEC042.
 	If Len(_aDivergencia) > 0					
 		NotificaDiv(_aDivergencia)
-	Endif	
+	Endif
+	//Liberar a chave	
+	If _lSemaforo
+		UnLockByName(_cChave,.T.,.T.)
+	Endif 
 Return .T.
 
 /*

--- a/Integracoes/RgLog - SILT/ZWSR012.prw
+++ b/Integracoes/RgLog - SILT/ZWSR012.prw
@@ -168,7 +168,6 @@ Private _aJson		:= {}
 
 	//Caso esteja rodando onda não será permitido fazer a transferencia
 	_cChave += AllTrim(cEmpAnt)+AllTrim(cFilAnt)
-	_lSemaforo := .F. 	//Caso não utilize o semaforo para RGLOG desabilitar
 	If !LockByName(_cChave,.T.,.T.)  
 		//tentar locar por 10 segundos caso não consiga não prosseguir
 		_lRet := .F.

--- a/SIGAPEC/Funcao/ZPECF008.PRW
+++ b/SIGAPEC/Funcao/ZPECF008.PRW
@@ -72,21 +72,6 @@ Begin Sequence
 	If !_lZPECF008                             
 		Break
 	Endif        
-	//Garantir que o processamento seja unico
-	If !LockByName(_cChave,.T.,.T.)  
-		//tentar locar por 10 segundos caso não consiga não prosseguir
-		_lRet := .F.
-		For _nPos := 1 To 10
-			Sleep( 300 ) // Para o processamento por 3 segundos
-			If LockByName(_cChave,.T.,.T.)
-				_lRet := .T.
-			EndIf
-		Next		
-		If !_lRet
-			MSGINFO("Já existe um processamento em execução rotina "+_cChave+" , aguarde!", "[ZPECF008] - Atenção" )
-			Break
-		EndIf
-	EndIf
 	/* Retirado para utilizar as duas situações onde o orçamento total avalia fator de redução e o de item não  DAC 21/03/2023
 	If _lAvaliaOrc  .And. _lAvaliaItem  
 		Help( , ,"Atenção",,"Não é permitido avaliação de Crédito Total e por Item, rever parametrização com o ADM Sistemas !",4,1) //Atenção / Necessário informar os parâmetros 
@@ -182,6 +167,23 @@ Begin Sequence
 	_cAglutina 	:= ""
 	_aMensAglu	:= {}
 	//Carregar processo
+
+	//Garantir que o processamento seja unico
+	_cChave += AllTrim(cEmpAnt)+AllTrim(cFilAnt)
+	If !LockByName(_cChave,.T.,.T.)  
+		//tentar locar por 10 segundos caso não consiga não prosseguir
+		_lRet := .F.
+		For _nPos := 1 To 10
+			Sleep( 300 ) // Para o processamento por 3 segundos
+			If LockByName(_cChave,.T.,.T.)
+				_lRet := .T.
+			EndIf
+		Next		
+		If !_lRet
+			MSGINFO("Já existe um processamento em execução rotina "+_cChave+" , aguarde!", "[ZPECF008] - Atenção" )
+			Break
+		EndIf
+	EndIf
 	For _nPos := 1 To Len(_aArmazem)
 		NNR->(DbSetOrder(1)) //NNR_FILIAL+NNR_CODIGO                                                                                                                                           
 		NNR->(DbSeek(XFilial("NNR")+_aArmazem[_nPos]))
@@ -191,12 +193,13 @@ Begin Sequence
 			FwMsgRun(,{ |_oSay| ZPECF08PRC( _aRet, _aVar, _aCampos, _aChave, _aArmazem[_nPos], @_aOndaRel, @_oSay ) }, "Separação Orçamentos armazém "+_aArmazem[_nPos]+" - "+AllTrim(NNR->NNR_DESCRI)+", Aguarde...")  //Separação Orçamentos / Aguarde
 		Endif
 	Next
+	//Liberar a chave
+	UnLockByName(_cChave,.T.,.T.)
+
 	ZPECF08RESumo(_aOndaRel)
 	//Validadr aondarel se possui enviado
 	ZPECF08R07(_aOndaRel)
 End Sequence 
-//Liberar a chave
-UnLockByName(_cChave,.T.,.T.)
 If Select(_cAliasPesq) <> 0
 	(_cAliasPesq)->(DbCloseArea())
 	Ferase(_cAliasPesq+GetDBExtension())

--- a/SIGAPEC/Funcao/ZPECF008.PRW
+++ b/SIGAPEC/Funcao/ZPECF008.PRW
@@ -28,166 +28,179 @@ Responsável por Aglutinar e Separação do orçamento passando pelas fases automati
 
 /*/
 User Function ZPECF008()
-	Local _aSays	    := {}
-	Local _aButtons	    := {}
-	Local _cCadastro    := OemToAnsi(STR0001)   //"Separação Orçamento"
-	Local _cTitle  	    := OemToAnsi(STR0002)   //"Separação Orçamento"
-	Local _aPar    	    := {}
-	Local _aRet    	    := {}
-	Local _nRet			:= 0
-	Local _lZPECF008    := SuperGetMV( "CMV_PEC009"  ,,.T. )   //Parâmetro para indicação de utilização do programa tendo como Default Verdadeiro, não é necessário a criação do mesmo
-	//Local _lAvaliaOrc   := SuperGetMV( "CMV_PEC032"  ,,.F. )   //Parâmetro para indicação de utilização do programa tendo como Default Verdadeiro, não é necessário a criação do mesmo
-	//Local _lAvaliaItem  := SuperGetMV( "CMV_PEC033"  ,,.F. )   //Parâmetro para indicação de utilização do programa tendo como Default Verdadeiro, não é necessário a criação do mesmo
-	//Local _cArmazemFDR 	:= AllTrim(SuperGetMV( "CMV_PEC036" ,,"" ))   //Parâmetro para indicação de utilização de validação armazem Franco da Rocha
+Local _aSays	    := {}
+Local _aButtons	    := {}
+Local _cCadastro    := OemToAnsi(STR0001)   //"Separação Orçamento"
+Local _cTitle  	    := OemToAnsi(STR0002)   //"Separação Orçamento"
+Local _aPar    	    := {}
+Local _aRet    	    := {}
+Local _nRet			:= 0
+Local _lZPECF008    := SuperGetMV( "CMV_PEC009"  ,,.T. )   //Parâmetro para indicação de utilização do programa tendo como Default Verdadeiro, não é necessário a criação do mesmo
+//Local _lAvaliaOrc   := SuperGetMV( "CMV_PEC032"  ,,.F. )   //Parâmetro para indicação de utilização do programa tendo como Default Verdadeiro, não é necessário a criação do mesmo
+//Local _lAvaliaItem  := SuperGetMV( "CMV_PEC033"  ,,.F. )   //Parâmetro para indicação de utilização do programa tendo como Default Verdadeiro, não é necessário a criação do mesmo
+//Local _cArmazemFDR 	:= AllTrim(SuperGetMV( "CMV_PEC036" ,,"" ))   //Parâmetro para indicação de utilização de validação armazem Franco da Rocha
+Local _cArmazem    	:= AllTrim(SuperGetMV( "CMV_PEC050"  ,,"" ))   //Parâmetro para indicação de utilização do programa tendo como Default Verdadeiro, não é necessário a criação do mesmo
+Local _aArmazem 	:= {}
+//Local _cFilDe 	:= Space(TamSx3("VS1_FILIAL")[1])
+//Local _cFilAte	:= Space(TamSx3("VS1_FILIAL")[1])
+Local _cCliFatDe	:= Space(TamSx3("VS1_CLIFAT")[1])
+Local _cCliFatAte 	:= Space(TamSx3("VS1_CLIFAT")[1])
+Local _cLojaCFDe 	:= Space(TamSx3("VS1_LOJA")[1])
+Local _cLojaCFAte	:= Space(TamSx3("VS1_LOJA")[1])
+Local _dDataIni		:= CtoD(Space(08))
+Local _dDataFim		:= CtoD(Space(08))
+Local _cNumOrcDe	:= Space(TamSx3("VS1_NUMORC")[1])
+Local _cNumOrcAte	:= Space(TamSx3("VS1_NUMORC")[1])
+Local _cCodProd		:= Space(TamSx3("B1_COD")[1]) 
+Local _cCodMarca	:= Space(TamSx3("VE1_CODMAR")[1])
+Local _aVar			:= {}
+Local _aCampos		:= {}
+Local _cAliasPesq   := GetNextAlias()      
+Local _aChave 		:= {}
+Local _lJob   		:=	If( IsBlind(),.T.,.F.)
+Local _oSay			:= Nil
+Local _aOndaRel 	:= {}
+Local _cChave		:= "ZPECF008_ONDA"
+Local _nPos
+Local _cVar
+Local _lRet 
 
-	Local _cArmazem    	:= AllTrim(SuperGetMV( "CMV_PEC050"  ,,"" ))   //Parâmetro para indicação de utilização do programa tendo como Default Verdadeiro, não é necessário a criação do mesmo
-	Local _aArmazem 	:= {}
-	//Local _cFilDe 	:= Space(TamSx3("VS1_FILIAL")[1])
-	//Local _cFilAte	:= Space(TamSx3("VS1_FILIAL")[1])
-	Local _cCliFatDe	:= Space(TamSx3("VS1_CLIFAT")[1])
-	Local _cCliFatAte 	:= Space(TamSx3("VS1_CLIFAT")[1])
-	Local _cLojaCFDe 	:= Space(TamSx3("VS1_LOJA")[1])
-	Local _cLojaCFAte	:= Space(TamSx3("VS1_LOJA")[1])
-	Local _dDataIni		:= CtoD(Space(08))
-	Local _dDataFim		:= CtoD(Space(08))
-	Local _cNumOrcDe	:= Space(TamSx3("VS1_NUMORC")[1])
-	Local _cNumOrcAte	:= Space(TamSx3("VS1_NUMORC")[1])
-	Local _cCodProd		:= Space(TamSx3("B1_COD")[1]) 
-	Local _cCodMarca	:= Space(TamSx3("VE1_CODMAR")[1])
-	Local _aVar			:= {}
-	Local _aCampos		:= {}
-	Local _cAliasPesq   := GetNextAlias()      
-	Local _aChave 		:= {}
-	Local _lJob   		:=	If( IsBlind(),.T.,.F.)
-	Local _oSay			:= Nil
-	Local _aOndaRel 	:= {}
-	Local _nPos
-	Local _cVar
+Private _cAglutina 	:= ""
+Private _aMensAglu	:= {}
 
-	Private _cAglutina 	:= ""
-	Private _aMensAglu	:= {}
-	
-	Begin Sequence
-		If !_lZPECF008                             
+Begin Sequence
+	If !_lZPECF008                             
+		Break
+	Endif        
+	//Garantir que o processamento seja unico
+	If !LockByName(_cChave,.T.,.T.)  
+		//tentar locar por 10 segundos caso não consiga não prosseguir
+		_lRet := .F.
+		For _nPos := 1 To 10
+			Sleep( 300 ) // Para o processamento por 3 segundos
+			If LockByName(_cChave,.T.,.T.)
+				_lRet := .T.
+			EndIf
+		Next		
+		If !_lRet
+			MSGINFO("Já existe um processamento em execução rotina "+_cChave+" , aguarde!", "[ZPECF008] - Atenção" )
 			Break
-		Endif        
-		/* Retirado para utilizar as duas situações onde o orçamento total avalia fator de redução e o de item não  DAC 21/03/2023
-		If _lAvaliaOrc  .And. _lAvaliaItem  
-			Help( , ,"Atenção",,"Não é permitido avaliação de Crédito Total e por Item, rever parametrização com o ADM Sistemas !",4,1) //Atenção / Necessário informar os parâmetros 
-			_lRet := .F.
-			Break
-		Endif
-		*/
-		//If U_ZGENUSER( RetCodUsr() ,"ZPECF008" ,.T.)
-
-		If Empty(_cArmazem)
-			Help( , ,"Atenção",,"Não informado parâmetro CMV_PEC050 de Armazém a ser avaliado na Onda !",4,1) //Atenção / 
-			_lRet := .F.
-			Break	
-		Endif 
-		//_cArmazem  := FormatIn(_cArmazem,";")
-		_cVar := ""
-		For _nPos := 1 To Len(_cArmazem)
-			If SubsTr(_cArmazem,_nPos,1) == ";"  
-				AAdd(_aArmazem, _cVar )
-				_cVar := ""
-			Else	
-				_cVar += SubsTr(_cArmazem,_nPos,1)
-			Endif	
-		Next	
-		If !Empty(_cVar)
+		EndIf
+	EndIf
+	/* Retirado para utilizar as duas situações onde o orçamento total avalia fator de redução e o de item não  DAC 21/03/2023
+	If _lAvaliaOrc  .And. _lAvaliaItem  
+		Help( , ,"Atenção",,"Não é permitido avaliação de Crédito Total e por Item, rever parametrização com o ADM Sistemas !",4,1) //Atenção / Necessário informar os parâmetros 
+		_lRet := .F.
+		Break
+	Endif
+	*/
+	//If U_ZGENUSER( RetCodUsr() ,"ZPECF008" ,.T.)
+	If Empty(_cArmazem)
+		Help( , ,"Atenção",,"Não informado parâmetro CMV_PEC050 de Armazém a ser avaliado na Onda !",4,1) //Atenção / 
+		_lRet := .F.
+		Break	
+	Endif 
+	//_cArmazem  := FormatIn(_cArmazem,";")
+	_cVar := ""
+	For _nPos := 1 To Len(_cArmazem)
+		If SubsTr(_cArmazem,_nPos,1) == ";"  
 			AAdd(_aArmazem, _cVar )
+			_cVar := ""
+		Else	
+			_cVar += SubsTr(_cArmazem,_nPos,1)
+		Endif	
+	Next	
+	If !Empty(_cVar)
+		AAdd(_aArmazem, _cVar )
+	Endif
+	If Len(_aArmazem) == 0
+		Help( , ,"Atenção",,"Verificar parâmetro CMV_PEC050 de Armazém a ser avaliado na Onda, com problemas !",4,1) //Atenção / 
+		_lRet := .F.
+		Break	
+	Endif 
+	BeginSql Alias _cAliasPesq //Define o nome do alias temporário 
+		SELECT 	VX5.VX5_CHAVE,
+				VX5.VX5_CODIGO,
+				VX5.VX5_DESCRI
+		FROM  %Table:VX5% VX5 
+		WHERE 	VX5.VX5_FILIAL 	=  %xFilial:VX5% 
+			AND VX5.VX5_CHAVE 	IN ('Z00','Z01')
+			AND VX5.%notDel%
+		ORDER BY VX5.VX5_CHAVE, VX5.VX5_CODIGO	
+	EndSql
+	If (_cAliasPesq)->(Eof())  
+		Help( , ,"Atenção",,"Não foram encontrados Tipos de Pedidos e ou Tipos de Modal tabela VX5 !",4,1) //Atenção / Necessário informar os parâmetros 
+		_lRet := .F.
+		Break	
+	Endif
+	While (_cAliasPesq)->(!Eof())
+		Aadd(_aChave,{	AllTrim((_cAliasPesq)->VX5_CHAVE), ;
+						AllTrim((_cAliasPesq)->VX5_CODIGO),;
+						AllTrim((_cAliasPesq)->VX5_DESCRI),;
+						0,;   //Posição do Parametro selecionado
+						})
+		(_cAliasPesq)->(DbSkip())
+	EndDo	
+	//Aadd(_aPar,{1,OemToAnsi(STR003) ,_cFilDe 	,"@!"		,".T."	,"SM0" ,".T."	,50,.F.}) //"Filial de:"
+	//Aadd(_aPar,{1,OemToAnsi(STR004) ,_cFilAte	,"@!"		,".T."	,"SM0" ,".T."	,50,.T.}) //"Filial Ate:"
+	Aadd(_aPar,{1,OemToAnsi(STR0007) ,_cCliFatDe			,"@!"		,".T."	,"SA1" 	,".T."	,50,.F.}) //Cod. Cliente de
+	Aadd(_aPar,{1,OemToAnsi(STR0009) ,_cLojaCFDe			,"@!"		,".T."	, 		,".T."	,50,.F.}) //Loja Cliente de
+	Aadd(_aPar,{1,OemToAnsi(STR0008) ,_cCliFatAte			,"@!"		,".T."	,"SA1" 	,".T."	,50,.T.}) //Cod. Cliente Até
+	Aadd(_aPar,{1,OemToAnsi(STR0010) ,_cLojaCFAte			,"@!"		,".T."	, 		,".T."	,50,.T.}) //Loja Cliente até
+	Aadd(_aPar,{1,OemToAnsi(STR0011) ,_dDataIni				,"@D"		,".T."	, 		,".T."	,50,.F.}) //Data Inicial Orçamento
+	Aadd(_aPar,{1,OemToAnsi(STR0012) ,_dDataFim				,"@D"		,".T."	, 		,".T."	,50,.T.}) //Data Final Orçamento
+	Aadd(_aPar,{1,OemToAnsi(STR0013) ,_cNumOrcDe			,"@!"		,".T."	, 		,".T."	,50,.F.}) //Numero Orçamento de
+	Aadd(_aPar,{1,OemToAnsi(STR0014) ,_cNumOrcAte			,"@!"		,".T."	, 		,".T."	,50,.T.}) //Numero Orçamento Até
+	Aadd(_aPar,{1,OemToAnsi(STR0040) ,_cCodProd				,"@!"		,".T."	,"SB1" 	,".T."	,50,.F.}) //Código do Produto
+	Aadd(_aPar,{1,OemToAnsi(STR0041) ,_cCodMarca			,"@!"		,".T."	,"VE1" 	,".T."	,50,.T.}) //Código do marca
+	aAdd(_aPar,{3,OemToAnsi(STR0042) ,2 ,{STR0005,STR0006,STR0043}	,60,"",.F.})  //Descrição / 1=Sim 2=Não 3=Todos
+	For _nPos := 1 To Len(_aChave)
+		aAdd(_aPar,{3,OemToAnsi(_aChave[_nPos,3]) ,2 ,{STR0005,STR0006}	,60,"",.F.})  //Descrição / 1=Sim 2=Não
+		_aChave[_nPos,4] := Len(_aPar)
+	Next
+	aAdd(_aPar,{3,OemToAnsi(STR0039) ,2 ,{STR0005,STR0006}	,80,"",.F.})  //Todas Alternativas / 1=Sim 2=Não
+	aAdd(_aPar,{3,OemToAnsi(STR0044) ,2 ,{STR0005+" (Se orçamento inicial não preenchido e final com ZZZZZZZZ)",STR0006}	,175,"",.T.})  //BY PASS / 1=Sim 2=Não
+	// Monta Tela principal
+	AADD(_aSays,OemToAnsi(STR0020)) //Este Programa tem  como  Objetivo  realizar a separação de Produtos
+	AADD(_aSays,OemToAnsi(STR0030)) //constantes  no Orçamento, sendo aglutinado conforme  definições 
+	AADD(_aSays,OemToAnsi(STR0031)) //previas e enviando a quantidade para a separação dos orçamentos.
+	AADD(_aSays,OemToAnsi(STR0032)) //Clique no botão Parâmetros para alterar as definições da rotina. 
+	AADD(_aSays,OemToAnsi(STR0033)) //Depois clique no Botão OK.
+	AADD(_aSays,OemToAnsi("")) 		//""
+	AADD(_aSays,OemToAnsi("ARMAZÉNS DE PROCESSAMENTO DA ONDA ==> "+ AllTrim(_cArmazem))) //Depois clique no Botão OK.
+	AADD(_aButtons, { 1,.T.,{|o| FechaBatch(),_nRet:=1											}})
+	AADD(_aButtons, { 2,.T.,{|o| FechaBatch()													}})
+	AADD(_aButtons, { 5,.T.,{|o| ParamBox(_aPar,_cTitle,@_aRet,,,.T.,,,,"ZPECF008",.T.,.T.) 			}})
+	FormBatch( _cCadastro, _aSays, _aButtons )
+	If _nRet <> 1
+		Break
+	Endif
+	If Len(_aRet) == 0
+		Help( , ,OemToAnsi(STR0028),,OemToAnsi(STR0027),4,1) //Atenção / Necessário informar os parâmetros 
+		Break 
+	Endif
+	_cAglutina 	:= ""
+	_aMensAglu	:= {}
+	//Carregar processo
+	For _nPos := 1 To Len(_aArmazem)
+		NNR->(DbSetOrder(1)) //NNR_FILIAL+NNR_CODIGO                                                                                                                                           
+		NNR->(DbSeek(XFilial("NNR")+_aArmazem[_nPos]))
+		If _lJob
+			ZPECF08PRC( _aRet, _aVar, _aCampos, _aChave, _aArmazem[_nPos], @_aOndaRel )
+		Else
+			FwMsgRun(,{ |_oSay| ZPECF08PRC( _aRet, _aVar, _aCampos, _aChave, _aArmazem[_nPos], @_aOndaRel, @_oSay ) }, "Separação Orçamentos armazém "+_aArmazem[_nPos]+" - "+AllTrim(NNR->NNR_DESCRI)+", Aguarde...")  //Separação Orçamentos / Aguarde
 		Endif
-		If Len(_aArmazem) == 0
-			Help( , ,"Atenção",,"Verificar parâmetro CMV_PEC050 de Armazém a ser avaliado na Onda, com problemas !",4,1) //Atenção / 
-			_lRet := .F.
-			Break	
-		Endif 
-
-		BeginSql Alias _cAliasPesq //Define o nome do alias temporário 
-			SELECT 	VX5.VX5_CHAVE,
-					VX5.VX5_CODIGO,
-					VX5.VX5_DESCRI
-			FROM  %Table:VX5% VX5 
-			WHERE 	VX5.VX5_FILIAL 	=  %xFilial:VX5% 
-				AND VX5.VX5_CHAVE 	IN ('Z00','Z01')
-				AND VX5.%notDel%
-			ORDER BY VX5.VX5_CHAVE, VX5.VX5_CODIGO	
-		EndSql
-		If (_cAliasPesq)->(Eof())  
-			Help( , ,"Atenção",,"Não foram encontrados Tipos de Pedidos e ou Tipos de Modal tabela VX5 !",4,1) //Atenção / Necessário informar os parâmetros 
-			_lRet := .F.
-			Break	
-		Endif
-		While (_cAliasPesq)->(!Eof())
-			Aadd(_aChave,{	AllTrim((_cAliasPesq)->VX5_CHAVE), ;
-							AllTrim((_cAliasPesq)->VX5_CODIGO),;
-							AllTrim((_cAliasPesq)->VX5_DESCRI),;
-							0,;   //Posição do Parametro selecionado
-							})
-			(_cAliasPesq)->(DbSkip())
-		EndDo	
-		//Aadd(_aPar,{1,OemToAnsi(STR003) ,_cFilDe 	,"@!"		,".T."	,"SM0" ,".T."	,50,.F.}) //"Filial de:"
-		//Aadd(_aPar,{1,OemToAnsi(STR004) ,_cFilAte	,"@!"		,".T."	,"SM0" ,".T."	,50,.T.}) //"Filial Ate:"
-		Aadd(_aPar,{1,OemToAnsi(STR0007) ,_cCliFatDe			,"@!"		,".T."	,"SA1" 	,".T."	,50,.F.}) //Cod. Cliente de
-		Aadd(_aPar,{1,OemToAnsi(STR0009) ,_cLojaCFDe			,"@!"		,".T."	, 		,".T."	,50,.F.}) //Loja Cliente de
-		Aadd(_aPar,{1,OemToAnsi(STR0008) ,_cCliFatAte			,"@!"		,".T."	,"SA1" 	,".T."	,50,.T.}) //Cod. Cliente Até
-		Aadd(_aPar,{1,OemToAnsi(STR0010) ,_cLojaCFAte			,"@!"		,".T."	, 		,".T."	,50,.T.}) //Loja Cliente até
-		Aadd(_aPar,{1,OemToAnsi(STR0011) ,_dDataIni				,"@D"		,".T."	, 		,".T."	,50,.F.}) //Data Inicial Orçamento
-		Aadd(_aPar,{1,OemToAnsi(STR0012) ,_dDataFim				,"@D"		,".T."	, 		,".T."	,50,.T.}) //Data Final Orçamento
-		Aadd(_aPar,{1,OemToAnsi(STR0013) ,_cNumOrcDe			,"@!"		,".T."	, 		,".T."	,50,.F.}) //Numero Orçamento de
-		Aadd(_aPar,{1,OemToAnsi(STR0014) ,_cNumOrcAte			,"@!"		,".T."	, 		,".T."	,50,.T.}) //Numero Orçamento Até
-		Aadd(_aPar,{1,OemToAnsi(STR0040) ,_cCodProd				,"@!"		,".T."	,"SB1" 	,".T."	,50,.F.}) //Código do Produto
-		Aadd(_aPar,{1,OemToAnsi(STR0041) ,_cCodMarca			,"@!"		,".T."	,"VE1" 	,".T."	,50,.T.}) //Código do marca
-		aAdd(_aPar,{3,OemToAnsi(STR0042) ,2 ,{STR0005,STR0006,STR0043}	,60,"",.F.})  //Descrição / 1=Sim 2=Não 3=Todos
-		For _nPos := 1 To Len(_aChave)
-			aAdd(_aPar,{3,OemToAnsi(_aChave[_nPos,3]) ,2 ,{STR0005,STR0006}	,60,"",.F.})  //Descrição / 1=Sim 2=Não
-			_aChave[_nPos,4] := Len(_aPar)
-		Next
-		aAdd(_aPar,{3,OemToAnsi(STR0039) ,2 ,{STR0005,STR0006}	,80,"",.F.})  //Todas Alternativas / 1=Sim 2=Não
-		aAdd(_aPar,{3,OemToAnsi(STR0044) ,2 ,{STR0005+" (Se orçamento inicial não preenchido e final com ZZZZZZZZ)",STR0006}	,175,"",.T.})  //BY PASS / 1=Sim 2=Não
-
-		// Monta Tela principal
-		AADD(_aSays,OemToAnsi(STR0020)) //Este Programa tem  como  Objetivo  realizar a separação de Produtos
-		AADD(_aSays,OemToAnsi(STR0030)) //constantes  no Orçamento, sendo aglutinado conforme  definições 
-		AADD(_aSays,OemToAnsi(STR0031)) //previas e enviando a quantidade para a separação dos orçamentos.
-		AADD(_aSays,OemToAnsi(STR0032)) //Clique no botão Parâmetros para alterar as definições da rotina. 
-		AADD(_aSays,OemToAnsi(STR0033)) //Depois clique no Botão OK.
-		AADD(_aSays,OemToAnsi("")) 		//""
-		AADD(_aSays,OemToAnsi("ARMAZÉNS DE PROCESSAMENTO DA ONDA ==> "+ AllTrim(_cArmazem))) //Depois clique no Botão OK.
-
-		AADD(_aButtons, { 1,.T.,{|o| FechaBatch(),_nRet:=1											}})
-		AADD(_aButtons, { 2,.T.,{|o| FechaBatch()													}})
-		AADD(_aButtons, { 5,.T.,{|o| ParamBox(_aPar,_cTitle,@_aRet,,,.T.,,,,"ZPECF008",.T.,.T.) 			}})
-
-		FormBatch( _cCadastro, _aSays, _aButtons )
-		If _nRet <> 1
-			Break
-		Endif
-		If Len(_aRet) == 0
-			Help( , ,OemToAnsi(STR0028),,OemToAnsi(STR0027),4,1) //Atenção / Necessário informar os parâmetros 
-			Break 
-		Endif
-		_cAglutina 	:= ""
-		_aMensAglu	:= {}
-		//Carregar processo
-		For _nPos := 1 To Len(_aArmazem)
-			NNR->(DbSetOrder(1)) //NNR_FILIAL+NNR_CODIGO                                                                                                                                           
-			NNR->(DbSeek(XFilial("NNR")+_aArmazem[_nPos]))
-			If _lJob
-				ZPECF08PRC( _aRet, _aVar, _aCampos, _aChave, _aArmazem[_nPos], @_aOndaRel )
-			Else
-				FwMsgRun(,{ |_oSay| ZPECF08PRC( _aRet, _aVar, _aCampos, _aChave, _aArmazem[_nPos], @_aOndaRel, @_oSay ) }, "Separação Orçamentos armazém "+_aArmazem[_nPos]+" - "+AllTrim(NNR->NNR_DESCRI)+", Aguarde...")  //Separação Orçamentos / Aguarde
-			Endif
-		Next
-		ZPECF08RESumo(_aOndaRel)
-		//Validadr aondarel se possui enviado
-		ZPECF08R07(_aOndaRel)
-	End Sequence 
-	If Select(_cAliasPesq) <> 0
-		(_cAliasPesq)->(DbCloseArea())
-		Ferase(_cAliasPesq+GetDBExtension())
-	Endif  
+	Next
+	ZPECF08RESumo(_aOndaRel)
+	//Validadr aondarel se possui enviado
+	ZPECF08R07(_aOndaRel)
+End Sequence 
+//Liberar a chave
+UnLockByName(_cChave,.T.,.T.)
+If Select(_cAliasPesq) <> 0
+	(_cAliasPesq)->(DbCloseArea())
+	Ferase(_cAliasPesq+GetDBExtension())
+Endif  
 
 Return Nil
 


### PR DESCRIPTION
**Descrição: GAP258 - Inclusão de Semáforo no Processo da Onda
**

**Fonte:** ZWSR012 - Alterado
Ajuste01: implementada validação do Semáforo se o mesmo está criado devido ao processamento da Onda.
Ajuste02: implementado parâmetro CMV_PEC052, o mesmo esta como default F (Falso) criar o mesmo em Produção. Foi definido por Rosangela e Juarez que não será utilizado Semáforo de controle da RGLOG para o Protheus quando estiver realizando a integração RGLOG Conferência, implementado parâmetro CMV_PEC052 para poder habilitar a utilização deste semáforo ou não. 

**Fonte:** ZPECF008 - Alterado
. Ajuste01: Implementado no fonte ZPECF008 Criação de semáforo para controle de utilização da Onda, este Semáforo verificara a Empresa e Filial para validação, ou seja, caso a abertura seja em outra empresa e ou filial será um novo semáforo. Observar que o Controle será realizado verificando empresa e filial para que restrinja acessos a mesma rotina (Onda) e ou a rotina de Conferência ZWSR012

**Validação01:** O processo foi validado por Juarez (TOTVS), Rosangela(CAOA), Denilso (CAOA), Vinicius (RGLOG) 
