### PR TITLE
GAP267 - Desconsiderar o array aICMSST qd nao houver imposto

### DIFF
--- a/SIGAFAT/Função/nfesefaz.prw
+++ b/SIGAFAT/Função/nfesefaz.prw
@@ -8607,8 +8607,11 @@ If  !lIssQn
 				cString += '<valor>'+ConvType(nValDeson,15,4)+'</valor>'				
 			Else
 			    //************ Especifico Caoa ******************
-				cString += '<valor>'+ConvType(aICMSST[07],15,2)+'</valor>'
-	//			cString += '<valor>'+ConvType(0,15,2)+'</valor>'
+				If Len(aICMSST) >= 7
+					cString += '<valor>'+ConvType(aICMSST[07],15,2)+'</valor>'
+				Else
+					cString += '<valor>'+ConvType(0,15,2)+'</valor>'
+				EndIf
 			EndIf	
 	
 			cString += '<qtrib>'+ConvType(0,16,4)+'</qtrib>'


### PR DESCRIPTION
GAP267 - Desconsiderar o array aICMSST qd nao houver imposto

Descrição: Rotina não encontra um ELEMENTO dentro da ARRAY na função NFEITEM, no fonte NFESEFAZ.PRW.
                   Ajuste no Fonte na linha 8611 para desconsidera o array aICMSST, quando nao houver o imposto
Especificação Técnica:Não Possui
Manual Técnico: Não Possui
Termo de Entrega: Não Possui