### PR TITLE
Ajuste para receber a leitura do QrCode das etiquetas Hyundai

### DIFF
--- a/Ponto de Entrada/CBRETEAN_PE.prw
+++ b/Ponto de Entrada/CBRETEAN_PE.prw
@@ -91,6 +91,13 @@ If AllTrim( FunName() ) $ "ACDV110|WMSV090|WMSV095"
             cProduto := AllTrim( Substr( AllTrim( cCodBar ),11,13 ) )
             nQtdEmb := Val( Substr( AllTrim( cCodBar ),24,06 ) )
 
+        //ETIQUETA QrCode HYUNDAI COM 42 CARACTERES E ETIQUETAS COMEÇANDO COM XF - XK - XT - BS
+        Case ( Len( AllTrim( cCodBar ) ) == 42 ) .And. Substr( AllTrim( cCodBar ),1,2 ) $ "XF|XK|XT|BS"  
+            
+            // PRODUTO RECEBE DA POSIÇÃO 11 A 24
+            cProduto := AllTrim( Substr( AllTrim( cCodBar ),11,14 ) )
+            nQtdEmb := Val( Substr( AllTrim( cCodBar ),25,08 ) )
+
         //ETIQUETA NACIONAIS, CONTEM ESPAÇO NA SUA COMPOSIÇÃO, SENDO PRODUTO ANTES DO ESPAÇO E QTD APÓS ESPAÇO
         Case At( " ", AllTrim( cCodBar ) ) > 0
             


### PR DESCRIPTION
GAP283 | Realizar alteração na rotina ZWMS095 para atender ao processo de triagem de peças.

*Descrição: houve atualização da maneira que a informação é recebida fisicamente no processo, que antes o box continha um barcode com as informaçoes de LOTE|PRODUTO|QUANTIDADE. Essa mesma informação passou a vir em um QRCode, hoje nao tratado no sistema.

Especificação Técnica: [DEV19 - Especificação Funcional -movimentaçao de peças - WMSV095.pdf](https://github.com/user-attachments/files/17395718/DEV19.-.Especificacao.Funcional.-movimentacao.de.pecas.-.WMSV095.pdf)
Manual Técnico: Não Possui
Termo de Entrega: [Termo_Entrega - Transferencia de Produtos.pdf](https://github.com/user-attachments/files/17395746/Termo_Entrega.-.Transferencia.de.Produtos.pdf)
